### PR TITLE
Refresh movement wizards UI and add navigation safeguards

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Allinea PRIMA di ogni commit
+scripts/codex-pre.sh main >/dev/null 2>&1 || true
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Se sei indietro rispetto a origin/main, riallinea e poi push
+set -e
+git fetch origin main
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse @{u})
+BASE=$(git merge-base @ @{u})
+if [ "$LOCAL" = "$BASE" ]; then
+  scripts/codex-pre.sh main
+fi
+exit 0

--- a/app/Livewire/Movimenti/CaricoWizard.php
+++ b/app/Livewire/Movimenti/CaricoWizard.php
@@ -4,9 +4,11 @@ namespace App\Livewire\Movimenti;
 
 use App\Models\{Articolo, Magazzino, Movimento, Ubicazione};
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Illuminate\Validation\ValidationException;
 
 #[Layout('layouts.app')]
 class CaricoWizard extends Component
@@ -53,18 +55,40 @@ class CaricoWizard extends Component
 
     public function next(): void
     {
-        $this->validateStep($this->step);
-        if ($this->step === 2) {
-            $this->buildRiepilogo();
+        try {
+            $this->validateStep($this->step);
+
+            if ($this->step === 2) {
+                $this->buildRiepilogo();
+            }
+
+            $this->step = min($this->step + 1, $this->maxStep());
+            $this->resetErrorBag();
         }
-        $this->step++;
+        catch (ValidationException $e) {
+            $this->setErrorBag($e->validator->getMessageBag());
+            $this->addError('general', 'Controlla i campi evidenziati e riprova.');
+        }
+        catch (\Throwable $e) {
+            Log::error('Errore avanzamento wizard carico', [
+                'message' => $e->getMessage(),
+                'step' => $this->step,
+            ]);
+            $this->addError('general', 'Impossibile avanzare, riprova fra qualche istante.');
+        }
     }
 
     public function back(): void
     {
         if ($this->step > 1) {
             $this->step--;
+            $this->resetErrorBag('general');
         }
+    }
+
+    protected function maxStep(): int
+    {
+        return 3;
     }
 
     protected function validateStep(int $step): void

--- a/public/images/knit-fibers.svg
+++ b/public/images/knit-fibers.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="600" viewBox="0 0 960 600">
+  <defs>
+    <linearGradient id="threadGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fde68a"/>
+      <stop offset="50%" stop-color="#fbcfe8"/>
+      <stop offset="100%" stop-color="#bae6fd"/>
+    </linearGradient>
+    <pattern id="knitPattern" patternUnits="userSpaceOnUse" width="120" height="80">
+      <path d="M0,40 C40,0 80,80 120,40" fill="none" stroke="url(#threadGradient)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.55"/>
+      <path d="M0,80 C40,40 80,120 120,80" fill="none" stroke="#fbbf24" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.35"/>
+    </pattern>
+  </defs>
+  <rect width="960" height="600" fill="#fdf2f8"/>
+  <rect width="960" height="600" fill="url(#knitPattern)"/>
+  <rect width="960" height="600" fill="url(#threadGradient)" opacity="0.08"/>
+</svg>

--- a/public/images/loom-weave.svg
+++ b/public/images/loom-weave.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="320" viewBox="0 0 420 320">
+  <defs>
+    <linearGradient id="loomGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+    <linearGradient id="thread" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#fdf2f8"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+  </defs>
+  <rect width="420" height="320" rx="32" fill="#f5f3ff"/>
+  <rect x="30" y="40" width="360" height="240" rx="28" fill="url(#loomGradient)" opacity="0.15"/>
+  <g stroke="#8b5cf6" stroke-width="10" stroke-linecap="round" opacity="0.7">
+    <path d="M70 60v200M140 60v200M210 60v200M280 60v200M350 60v200"/>
+  </g>
+  <g stroke="#ec4899" stroke-width="6" stroke-linecap="round" opacity="0.6">
+    <path d="M60 110h300M60 150h300M60 190h300"/>
+  </g>
+  <g fill="url(#thread)" opacity="0.8">
+    <rect x="75" y="80" width="40" height="160" rx="12"/>
+    <rect x="215" y="80" width="40" height="160" rx="12"/>
+    <rect x="285" y="80" width="40" height="160" rx="12"/>
+  </g>
+</svg>

--- a/public/images/warehouse-racks.svg
+++ b/public/images/warehouse-racks.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360" viewBox="0 0 480 360">
+  <defs>
+    <linearGradient id="rackGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+    <linearGradient id="boxGradient" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#facc15"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="360" rx="32" fill="url(#rackGradient)" opacity="0.12"/>
+  <g fill="none" stroke="#1d4ed8" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.65">
+    <path d="M60 60v240M180 60v240M300 60v240M420 60v240"/>
+    <path d="M40 100h400M40 180h400M40 260h400"/>
+  </g>
+  <g fill="url(#boxGradient)" opacity="0.75">
+    <rect x="70" y="70" width="90" height="50" rx="8"/>
+    <rect x="310" y="150" width="90" height="50" rx="8"/>
+    <rect x="190" y="230" width="90" height="50" rx="8"/>
+  </g>
+  <g fill="#fde68a" opacity="0.6">
+    <rect x="200" y="90" width="80" height="40" rx="6"/>
+    <rect x="90" y="210" width="80" height="40" rx="6"/>
+    <rect x="320" y="230" width="80" height="40" rx="6"/>
+  </g>
+</svg>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -45,4 +45,77 @@
   }
   .tile-title { @apply mt-2 text-base font-semibold; }
   .tile-sub   { @apply text-xs text-slate-600 dark:text-slate-400; }
+
+  .wizard-frame {
+    @apply relative isolate overflow-hidden rounded-[36px] border border-white/70 bg-white/80 shadow-xl backdrop-blur-lg ring-1 ring-slate-200/60;
+  }
+
+  .wizard-frame::before {
+    content: '';
+    @apply absolute inset-0 bg-gradient-to-br from-amber-50 via-white to-sky-50 opacity-90;
+  }
+
+  .wizard-frame::after {
+    content: '';
+    background-image: url('/images/knit-fibers.svg');
+    background-size: cover;
+    background-repeat: repeat;
+    @apply absolute inset-0 opacity-20 mix-blend-multiply;
+  }
+
+  .wizard-surface {
+    @apply relative z-10 space-y-8 p-6 sm:p-8 lg:p-10;
+  }
+
+  .wizard-hero {
+    @apply grid gap-6 lg:grid-cols-[1fr_auto] items-center;
+  }
+
+  .wizard-hero-badge {
+    @apply inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase text-amber-700 shadow-sm;
+  }
+
+  .wizard-stepper {
+    @apply rounded-3xl border border-white/80 bg-white/70 shadow-inner backdrop-blur;
+  }
+
+  .wizard-stepper ol {
+    @apply grid gap-4 sm:grid-cols-2 lg:flex lg:flex-row lg:items-center lg:justify-between px-4 py-5 text-sm;
+  }
+
+  .wizard-stepper li {
+    @apply flex items-center gap-3;
+  }
+
+  .wizard-step-indicator {
+    @apply flex h-10 w-10 items-center justify-center rounded-full border-2 font-semibold transition-all duration-200;
+  }
+
+  .wizard-panel {
+    @apply space-y-5 rounded-3xl border border-white/70 bg-white/80 p-6 shadow-sm backdrop-blur;
+  }
+
+  .wizard-panel h2 {
+    @apply text-lg font-semibold text-slate-800;
+  }
+
+  .wizard-error {
+    @apply rounded-2xl border border-rose-200 bg-rose-50/70 px-4 py-3 text-sm font-medium text-rose-700 shadow-sm;
+  }
+
+  .wizard-success {
+    @apply rounded-2xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm font-medium text-emerald-700 shadow-sm;
+  }
+}
+
+@layer utilities {
+  .wizard-gradient {
+    @apply bg-gradient-to-br from-fuchsia-100 via-amber-50 to-cyan-100;
+  }
+
+  .wizard-grid-overlay {
+    background-image: linear-gradient(to right, rgba(15, 23, 42, 0.05) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(15, 23, 42, 0.05) 1px, transparent 1px);
+    background-size: 40px 40px;
+  }
 }

--- a/resources/views/livewire/movimenti/carico-wizard.blade.php
+++ b/resources/views/livewire/movimenti/carico-wizard.blade.php
@@ -1,166 +1,219 @@
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Registrazione carico</h1>
-
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Dati generali',2=>'Articoli',3=>'Riepilogo'] as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-green-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
-
-  @if($step === 1)
-    <div class="card space-y-4">
-      <div>
-        <label class="block text-sm font-medium">Magazzino di destinazione</label>
-        <select wire:model="contesto.magazzino_id" class="w-full border rounded-xl p-2">
-          <option value="">— seleziona —</option>
-          @foreach($magazzini as $m)
-            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-          @endforeach
-        </select>
-        @error('contesto.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-      </div>
-
-      @if($ubicazioni->isNotEmpty())
-        <div>
-          <label class="block text-sm font-medium">Ubicazione</label>
-          <select wire:model="contesto.ubicazione_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ubicazioni as $u)
-              <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-            @endforeach
-          </select>
-          @error('contesto.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+<div class="mx-auto max-w-6xl px-4 py-6">
+  <div class="wizard-frame wizard-grid-overlay">
+    <div class="wizard-surface" wire:key="carico-step-shell">
+      <div class="wizard-hero">
+        <div class="space-y-3">
+          <span class="wizard-hero-badge">Nuovo carico</span>
+          <h1 class="text-3xl font-semibold text-slate-900">
+            Registra il carico di filati e accessori in pochi passi
+          </h1>
+          <p class="text-sm text-slate-600 leading-relaxed">
+            Completa i campi richiesti e traccia i movimenti di magazzino con una grafica ispirata alla maglieria.
+            I passaggi successivi si attivano automaticamente quando i dati sono validi.
+          </p>
         </div>
-      @elseif($contesto['magazzino_id'])
-        <p class="text-xs text-slate-500">Il magazzino selezionato non ha ubicazioni attive: il carico sarà registrato a livello magazzino.</p>
+        <div class="hidden lg:block">
+          <img src="{{ asset('images/warehouse-racks.svg') }}" alt="Illustrazione di scaffalature di magazzino" class="h-48 w-auto drop-shadow-xl" />
+        </div>
+      </div>
+
+      @php
+        $wizardSteps = [
+          1 => 'Dati generali',
+          2 => 'Articoli',
+          3 => 'Riepilogo',
+        ];
+      @endphp
+
+      <div class="wizard-stepper">
+        <ol>
+          @foreach($wizardSteps as $i => $label)
+            <li>
+              <div class="wizard-step-indicator {{ $step >= $i ? 'border-emerald-500 bg-emerald-500 text-white shadow-lg shadow-emerald-200/80' : 'border-slate-200 bg-white text-slate-500' }}">
+                {{ $i }}
+              </div>
+              <div class="flex flex-col">
+                <span class="font-semibold {{ $step >= $i ? 'text-slate-900' : 'text-slate-500' }}">{{ $label }}</span>
+                <span class="text-xs text-slate-400">Passo {{ $i }} di {{ count($wizardSteps) }}</span>
+              </div>
+            </li>
+          @endforeach
+        </ol>
+      </div>
+
+      @if ($errors->has('general'))
+        <div class="wizard-error">{{ $errors->first('general') }}</div>
+      @endif
+      @if (session('ok'))
+        <div class="wizard-success">{{ session('ok') }}</div>
       @endif
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm">Commessa</label>
-          <input type="text" wire:model.lazy="contesto.commessa" class="w-full border rounded-xl p-2" placeholder="Es. PRJ-2025" />
-          @error('contesto.commessa')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Riferimento documento</label>
-          <input type="text" wire:model.lazy="contesto.riferimento" class="w-full border rounded-xl p-2" placeholder="DDT, ordine..." />
-          @error('contesto.riferimento')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Bagno</label>
-          <input type="text" wire:model.lazy="contesto.bagno" class="w-full border rounded-xl p-2" />
-        </div>
-        <div>
-          <label class="block text-sm">Linea</label>
-          <input type="text" wire:model.lazy="contesto.linea" class="w-full border rounded-xl p-2" />
-        </div>
-      </div>
+      <div class="space-y-8" wire:key="carico-step-{{ $step }}">
+        @if($step === 1)
+          <div class="wizard-panel">
+            <div class="grid gap-5 lg:grid-cols-2">
+              <div class="space-y-4">
+                <label class="block text-sm font-medium text-slate-700">Magazzino di destinazione</label>
+                <select wire:model.live="contesto.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500">
+                  <option value="">— seleziona —</option>
+                  @foreach($magazzini as $m)
+                    <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                  @endforeach
+                </select>
+                @error('contesto.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
 
-      <div>
-        <label class="block text-sm">Note operative</label>
-        <textarea wire:model.lazy="contesto.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Indicazioni per il magazzino..."></textarea>
-      </div>
-    </div>
-  @endif
+                @if($ubicazioni->isNotEmpty())
+                  <div class="space-y-2">
+                    <label class="block text-sm font-medium text-slate-700">Ubicazione interna</label>
+                    <select wire:model.live="contesto.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500">
+                      <option value="">— seleziona —</option>
+                      @foreach($ubicazioni as $u)
+                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                      @endforeach
+                    </select>
+                    @error('contesto.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                @elseif($contesto['magazzino_id'])
+                  <p class="text-xs text-slate-500">Il magazzino selezionato non ha ubicazioni attive: il carico sarà registrato a livello magazzino.</p>
+                @endif
+              </div>
 
-  @if($step === 2)
-    <div class="card space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="font-medium">Articoli in ingresso</h2>
-        <button type="button" wire:click="addRiga" class="btn-secondary">+ Aggiungi riga</button>
-      </div>
+              <div class="space-y-4">
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Commessa</label>
+                    <input type="text" wire:model.live="contesto.commessa" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" placeholder="Es. PRJ-2025" />
+                    @error('contesto.commessa')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Riferimento documento</label>
+                    <input type="text" wire:model.live="contesto.riferimento" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" placeholder="DDT, ordine..." />
+                    @error('contesto.riferimento')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Bagno</label>
+                    <input type="text" wire:model.live="contesto.bagno" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" />
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Linea</label>
+                    <input type="text" wire:model.live="contesto.linea" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" />
+                  </div>
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-slate-700">Note operative</label>
+                  <textarea wire:model.live="contesto.note" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" placeholder="Indicazioni per il magazzino..."></textarea>
+                </div>
+              </div>
+            </div>
+          </div>
+        @endif
 
-      @foreach($righe as $i => $riga)
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-end">
-          <div class="md:col-span-6">
-            <label class="block text-sm">Articolo</label>
-            <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($articoli as $a)
-                <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+        @if($step === 2)
+          <div class="wizard-panel space-y-6">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h2>Articoli in ingresso</h2>
+                <p class="text-sm text-slate-500">Aggiungi le bobine, i filati o gli accessori che entrano in magazzino.</p>
+              </div>
+              <button type="button" wire:click="addRiga" class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-700 shadow-sm transition hover:bg-emerald-200">
+                <span class="text-lg">＋</span> Aggiungi riga
+              </button>
+            </div>
+
+            <div class="space-y-5">
+              @foreach($righe as $i => $riga)
+                <div class="rounded-3xl border border-emerald-100/80 bg-white/90 p-5 shadow-inner" wire:key="carico-riga-{{ $i }}">
+                  <div class="grid gap-4 md:grid-cols-12 md:items-end">
+                    <div class="md:col-span-6">
+                      <label class="block text-sm font-medium text-slate-700">Articolo</label>
+                      <select wire:model.live="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500">
+                        <option value="">— seleziona —</option>
+                        @foreach($articoli as $a)
+                          <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                        @endforeach
+                      </select>
+                      @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-3">
+                      <label class="block text-sm font-medium text-slate-700">Q.tà (kg/pz)</label>
+                      <input type="number" step="0.001" min="0" wire:model.live="righe.{{ $i }}.qta" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" />
+                      @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-2">
+                      <label class="block text-sm font-medium text-slate-700">Lotto</label>
+                      <input type="text" wire:model.live="righe.{{ $i }}.lotto" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-emerald-500 focus:ring-emerald-500" />
+                      @error("righe.$i.lotto")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-1">
+                      <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-100">🗑️</button>
+                    </div>
+                  </div>
+                </div>
               @endforeach
-            </select>
-            @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
           </div>
-          <div class="md:col-span-3">
-            <label class="block text-sm">Q.tà (kg/pz)</label>
-            <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-2">
-            <label class="block text-sm">Lotto</label>
-            <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.lotto")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-1">
-            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-xl p-2 hover:bg-red-50">🗑️</button>
-          </div>
-        </div>
-        <hr class="border-dashed">
-      @endforeach
-    </div>
-  @endif
+        @endif
 
-  @if($step === 3)
-    <div class="card space-y-4">
-      <h2 class="font-medium">Riepilogo carico</h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div>
-          <div class="font-semibold">Magazzino</div>
-          <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-          @if($riepilogo['ubicazione'] ?? false)
-            <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-          @endif
-        </div>
-        <div>
-          <div class="font-semibold">Commessa</div>
-          <div>{{ $contesto['commessa'] ?: '—' }}</div>
-          <div class="text-xs text-slate-500">Rif: {{ $contesto['riferimento'] ?: '—' }}</div>
-        </div>
+        @if($step === 3)
+          <div class="wizard-panel space-y-6">
+            <div>
+              <h2>Riepilogo carico</h2>
+              <p class="text-sm text-slate-500">Verifica i dati prima di confermare il movimento in magazzino.</p>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2 text-sm">
+              <div class="rounded-2xl border border-emerald-100/70 bg-emerald-50/60 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-emerald-600">Magazzino</div>
+                <div class="text-base font-semibold text-slate-800">{{ $riepilogo['magazzino'] ?? '—' }}</div>
+                @if($riepilogo['ubicazione'] ?? false)
+                  <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
+                @endif
+              </div>
+              <div class="rounded-2xl border border-amber-100/70 bg-amber-50/60 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-amber-600">Commessa</div>
+                <div class="text-base font-semibold text-slate-800">{{ $contesto['commessa'] ?: '—' }}</div>
+                <div class="text-xs text-slate-500">Rif: {{ $contesto['riferimento'] ?: '—' }}</div>
+              </div>
+            </div>
+            <div class="overflow-hidden rounded-3xl border border-slate-200/60">
+              <table class="min-w-full divide-y divide-slate-200 text-sm">
+                <thead class="bg-slate-50/60">
+                  <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Articolo</th>
+                    <th class="px-4 py-3 text-right font-semibold text-slate-600">Q.tà</th>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Lotto</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-100 bg-white/80">
+                  @foreach($riepilogo['righe'] ?? [] as $r)
+                    <tr>
+                      <td class="px-4 py-3">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                      <td class="px-4 py-3 text-right font-medium text-slate-700">{{ $r['qta'] }}</td>
+                      <td class="px-4 py-3 text-slate-500">{{ $r['lotto'] ?: '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          </div>
+        @endif
       </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="text-left py-2">Articolo</th>
-              <th class="text-right">Q.tà</th>
-              <th class="text-left">Lotto</th>
-            </tr>
-          </thead>
-          <tbody>
-            @foreach($riepilogo['righe'] ?? [] as $r)
-              <tr class="border-b">
-                <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                <td class="text-right">{{ $r['qta'] }}</td>
-                <td>{{ $r['lotto'] ?: '—' }}</td>
-              </tr>
-            @endforeach
-          </tbody>
-        </table>
+
+      <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        <button type="button" class="btn-secondary" wire:click="back" wire:target="back" wire:loading.attr="disabled" @disabled($step===1)>
+          Indietro
+        </button>
+        @if($step < 3)
+          <button type="button" class="btn-primary bg-gradient-to-r from-emerald-500 to-emerald-600" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="next">Avanti</span>
+            <span wire:loading wire:target="next">Controllo dati…</span>
+          </button>
+        @else
+          <button type="button" class="btn-primary bg-gradient-to-r from-emerald-500 to-emerald-600" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="conferma">Conferma carico</span>
+            <span wire:loading wire:target="conferma">Salvataggio…</span>
+          </button>
+        @endif
       </div>
     </div>
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma carico</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
   </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/resources/views/livewire/movimenti/conto-lavoro-wizard.blade.php
+++ b/resources/views/livewire/movimenti/conto-lavoro-wizard.blade.php
@@ -1,303 +1,330 @@
-<div class="mx-auto max-w-6xl p-4 space-y-6">
-  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-    <h1 class="text-2xl font-semibold">Gestione conto lavoro</h1>
-    <div class="flex rounded-xl border border-slate-200 dark:border-slate-700 overflow-hidden">
-      <button type="button" wire:click="switchFase('invio')" class="px-4 py-2 text-sm font-medium {{ $fase === 'invio' ? 'bg-brand-600 text-white' : 'bg-white dark:bg-slate-900' }}">Invio ai terzisti</button>
-      <button type="button" wire:click="switchFase('rientro')" class="px-4 py-2 text-sm font-medium {{ $fase === 'rientro' ? 'bg-brand-600 text-white' : 'bg-white dark:bg-slate-900' }}">Rientro lavorazioni</button>
+<div class="mx-auto max-w-6xl px-4 py-6">
+  <div class="wizard-frame wizard-grid-overlay">
+    <div class="wizard-surface" wire:key="conto-step-shell">
+      <div class="wizard-hero">
+        <div class="space-y-3">
+          <span class="wizard-hero-badge bg-violet-100 text-violet-700">Conto lavoro</span>
+          <h1 class="text-3xl font-semibold text-slate-900">Coordina invii e rientri ai terzisti con stile sartoriale</h1>
+          <p class="text-sm text-slate-600 leading-relaxed">
+            Passa da invio a rientro in un click, compila i dati e ottieni un riepilogo chiaro con colori ispirati alla maglieria.
+          </p>
+        </div>
+        <div class="hidden lg:block">
+          <img src="{{ asset('images/loom-weave.svg') }}" alt="Telaio di maglieria" class="h-48 w-auto drop-shadow-xl" />
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/70 bg-white/70 p-3 shadow-inner">
+        <div class="text-sm font-medium text-slate-700">Fase di lavoro</div>
+        <div class="flex gap-2">
+          <button type="button" wire:click="switchFase('invio')" class="rounded-full px-4 py-2 text-sm font-semibold transition {{ $fase === 'invio' ? 'bg-violet-500 text-white shadow-lg' : 'bg-white/80 text-slate-600 hover:bg-slate-100' }}">Invio ai terzisti</button>
+          <button type="button" wire:click="switchFase('rientro')" class="rounded-full px-4 py-2 text-sm font-semibold transition {{ $fase === 'rientro' ? 'bg-violet-500 text-white shadow-lg' : 'bg-white/80 text-slate-600 hover:bg-slate-100' }}">Rientro lavorazioni</button>
+        </div>
+      </div>
+
+      @php($labels = $fase === 'invio' ? [1=>'Dati invio',2=>'Articoli',3=>'Riepilogo'] : [1=>'Ordine e magazzino',2=>'Quantità rientro',3=>'Riepilogo'])
+
+      <div class="wizard-stepper">
+        <ol>
+          @foreach ($labels as $i => $label)
+            <li>
+              <div class="wizard-step-indicator {{ $step >= $i ? 'border-violet-500 bg-violet-500 text-white shadow-lg shadow-violet-200/80' : 'border-slate-200 bg-white text-slate-500' }}">
+                {{ $i }}
+              </div>
+              <div class="flex flex-col">
+                <span class="font-semibold {{ $step >= $i ? 'text-slate-900' : 'text-slate-500' }}">{{ $label }}</span>
+                <span class="text-xs text-slate-400">Passo {{ $i }} di {{ count($labels) }}</span>
+              </div>
+            </li>
+          @endforeach
+        </ol>
+      </div>
+
+      @if ($errors->has('general'))
+        <div class="wizard-error">{{ $errors->first('general') }}</div>
+      @endif
+      @if (session('ok'))
+        <div class="wizard-success">{{ session('ok') }}</div>
+      @endif
+
+      <div class="space-y-8" wire:key="conto-step-{{ $fase }}-{{ $step }}">
+        @if($fase === 'invio')
+          @if($step === 1)
+            <div class="wizard-panel space-y-6">
+              <div class="grid gap-4 md:grid-cols-2">
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Terzista</label>
+                  <select wire:model.live="invio.terzista_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($terzisti as $t)
+                      <option value="{{ $t->id }}">{{ $t->ragione_sociale }}</option>
+                    @endforeach
+                  </select>
+                  @error('invio.terzista_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Magazzino di uscita</label>
+                  <select wire:model.live="invio.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($magazzini as $m)
+                      <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                    @endforeach
+                  </select>
+                  @error('invio.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Ubicazione</label>
+                  <select wire:model.live="invio.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($ubicazioniInvio as $u)
+                      <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                    @endforeach
+                  </select>
+                  @error('invio.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Data invio</label>
+                    <input type="date" wire:model.live="invio.data_invio" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                    @error('invio.data_invio')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Rientro previsto</label>
+                    <input type="date" wire:model.live="invio.data_rientro_prevista" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                    @error('invio.data_rientro_prevista')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700">Note per il terzista</label>
+                <textarea wire:model.live="invio.note" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" placeholder="Indicazioni, componenti, urgenze..."></textarea>
+                @error('invio.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+            </div>
+          @endif
+
+          @if($step === 2)
+            <div class="wizard-panel space-y-6">
+              <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <h2>Articoli da inviare</h2>
+                  <p class="text-sm text-slate-500">Elenca i materiali destinati al terzista.</p>
+                </div>
+                <button type="button" class="inline-flex items-center gap-2 rounded-full bg-violet-100 px-4 py-2 text-sm font-medium text-violet-700 shadow-sm transition hover:bg-violet-200" wire:click="addRiga">
+                  <span class="text-lg">＋</span> Aggiungi riga
+                </button>
+              </div>
+
+              <div class="space-y-5">
+                @foreach($righe as $i => $riga)
+                  <div class="rounded-3xl border border-violet-100/80 bg-white/90 p-5 shadow-inner" wire:key="invio-riga-{{ $i }}">
+                    <div class="grid gap-4 lg:grid-cols-12 lg:items-end">
+                      <div class="lg:col-span-5">
+                        <label class="block text-sm font-medium text-slate-700">Articolo</label>
+                        <select wire:model.live="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                          <option value="">— seleziona —</option>
+                          @foreach($articoli as $a)
+                            <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                          @endforeach
+                        </select>
+                        @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                      </div>
+                      <div class="lg:col-span-2">
+                        <label class="block text-sm font-medium text-slate-700">Q.tà</label>
+                        <input type="number" step="0.001" min="0" wire:model.live="righe.{{ $i }}.qta" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                        @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                      </div>
+                      <div class="lg:col-span-2">
+                        <label class="block text-sm font-medium text-slate-700">Lotto</label>
+                        <input type="text" wire:model.live="righe.{{ $i }}.lotto" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                      </div>
+                      <div class="lg:col-span-3">
+                        <label class="block text-sm font-medium text-slate-700">Componenti / lavorazioni</label>
+                        <input type="text" wire:model.live="righe.{{ $i }}.componenti" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" placeholder="Es. fodera, bottoni..." />
+                      </div>
+                    </div>
+                  </div>
+                @endforeach
+              </div>
+            </div>
+          @endif
+
+          @if($step === 3)
+            <div class="wizard-panel space-y-6">
+              <div>
+                <h2>Riepilogo invio</h2>
+                <p class="text-sm text-slate-500">Conferma le informazioni prima di registrare la spedizione.</p>
+              </div>
+              <div class="grid gap-4 md:grid-cols-2 text-sm">
+                <div class="rounded-2xl border border-violet-100/70 bg-violet-50/60 p-4">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-violet-600">Terzista</div>
+                  <div class="text-base font-semibold text-slate-800">{{ $riepilogo['terzista'] ?? '—' }}</div>
+                  <div class="text-xs text-slate-500">Magazzino: {{ $riepilogo['magazzino'] ?? '—' }}</div>
+                </div>
+                <div class="rounded-2xl border border-amber-100/70 bg-amber-50/60 p-4">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-600">Date</div>
+                  <div class="text-base font-semibold text-slate-800">Invio: {{ $invio['data_invio'] }}</div>
+                  <div class="text-xs text-slate-500">Rientro previsto: {{ $invio['data_rientro_prevista'] ?: '—' }}</div>
+                </div>
+              </div>
+              <div class="overflow-hidden rounded-3xl border border-slate-200/60">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-50/60">
+                    <tr>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-600">Articolo</th>
+                      <th class="px-4 py-3 text-right font-semibold text-slate-600">Q.tà</th>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-600">Lotto</th>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-600">Componenti</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100 bg-white/80">
+                    @foreach($riepilogo['righe'] ?? [] as $r)
+                      <tr>
+                        <td class="px-4 py-3">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                        <td class="px-4 py-3 text-right font-medium text-slate-700">{{ $r['qta'] }}</td>
+                        <td class="px-4 py-3 text-slate-500">{{ $r['lotto'] ?: '—' }}</td>
+                        <td class="px-4 py-3 text-slate-500">{{ $r['componenti'] ?: '—' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          @endif
+        @else
+          @if($step === 1)
+            <div class="wizard-panel space-y-6">
+              <div class="grid gap-4 md:grid-cols-2">
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Ordine conto lavoro</label>
+                  <select wire:model.live="rientro.ordine_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($ordiniAperti as $ordine)
+                      <option value="{{ $ordine->id }}">#{{ $ordine->id }} — {{ $ordine->terzista?->ragione_sociale }} ({{ $ordine->stato }})</option>
+                    @endforeach
+                  </select>
+                  @error('rientro.ordine_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Magazzino di rientro</label>
+                  <select wire:model.live="rientro.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($magazzini as $m)
+                      <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                    @endforeach
+                  </select>
+                  @error('rientro.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Ubicazione</label>
+                  <select wire:model.live="rientro.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($ubicazioniRientro as $u)
+                      <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                    @endforeach
+                  </select>
+                  @error('rientro.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slate-700">Note di rientro</label>
+                <textarea wire:model.live="rientro.note" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" placeholder="Eventuali annotazioni..."></textarea>
+                @error('rientro.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+            </div>
+          @endif
+
+          @if($step === 2)
+            <div class="wizard-panel space-y-6">
+              <div>
+                <h2>Quantità di rientro</h2>
+                <p class="text-sm text-slate-500">Indica quanto rientra e gli eventuali scarti per ogni riga dell'ordine.</p>
+              </div>
+              <div class="space-y-5">
+                @foreach($rientroRighe as $i => $riga)
+                  <div class="rounded-3xl border border-violet-100/80 bg-white/90 p-5 shadow-inner" wire:key="rientro-riga-{{ $riga['id'] }}">
+                    <div class="grid gap-4 lg:grid-cols-12 lg:items-end">
+                      <div class="lg:col-span-4">
+                        <div class="text-sm font-semibold text-slate-800">{{ $riga['articolo'] }}</div>
+                        <div class="text-xs text-slate-500">Inviato: {{ $riga['qta_inviata'] }} — Disponibile: {{ $riga['disponibile'] }}</div>
+                      </div>
+                      <div class="lg:col-span-3">
+                        <label class="block text-sm font-medium text-slate-700">Rientro</label>
+                        <input type="number" step="0.001" min="0" max="{{ $riga['disponibile'] }}" wire:model.live="rientroRighe.{{ $i }}.qta_rientro" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                        @error("rientroRighe.$i.qta_rientro")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                      </div>
+                      <div class="lg:col-span-3">
+                        <label class="block text-sm font-medium text-slate-700">Scarto</label>
+                        <input type="number" step="0.001" min="0" wire:model.live="rientroRighe.{{ $i }}.scarto" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-violet-500 focus:ring-violet-500" />
+                        @error("rientroRighe.$i.scarto")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                      </div>
+                      <div class="lg:col-span-2">
+                        <div class="text-xs text-slate-500">Lotto: {{ $riga['lotto'] ?: '—' }}</div>
+                      </div>
+                    </div>
+                  </div>
+                @endforeach
+              </div>
+            </div>
+          @endif
+
+          @if($step === 3)
+            <div class="wizard-panel space-y-6">
+              <div>
+                <h2>Riepilogo rientro</h2>
+                <p class="text-sm text-slate-500">Conferma i dati per chiudere il conto lavoro.</p>
+              </div>
+              <div class="grid gap-4 md:grid-cols-2 text-sm">
+                <div class="rounded-2xl border border-violet-100/70 bg-violet-50/60 p-4">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-violet-600">Ordine</div>
+                  <div class="text-base font-semibold text-slate-800">#{{ $rientro['ordine_id'] }}</div>
+                </div>
+                <div class="rounded-2xl border border-emerald-100/70 bg-emerald-50/60 p-4">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-emerald-600">Magazzino</div>
+                  <div class="text-base font-semibold text-slate-800">{{ optional($magazzini->firstWhere('id', $rientro['magazzino_id']))?->descrizione }}</div>
+                </div>
+              </div>
+              <div class="overflow-hidden rounded-3xl border border-slate-200/60">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-50/60">
+                    <tr>
+                      <th class="px-4 py-3 text-left font-semibold text-slate-600">Articolo</th>
+                      <th class="px-4 py-3 text-right font-semibold text-slate-600">Rientro</th>
+                      <th class="px-4 py-3 text-right font-semibold text-slate-600">Scarto</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100 bg-white/80">
+                    @foreach($rientroRighe as $r)
+                      <tr>
+                        <td class="px-4 py-3">{{ $r['articolo'] }}</td>
+                        <td class="px-4 py-3 text-right font-medium text-slate-700">{{ $r['qta_rientro'] ?: '—' }}</td>
+                        <td class="px-4 py-3 text-right text-slate-500">{{ $r['scarto'] ?: '—' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          @endif
+        @endif
+      </div>
+
+      <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        <button type="button" class="btn-secondary" wire:click="back" wire:target="back" wire:loading.attr="disabled" @disabled($step===1)>
+          Indietro
+        </button>
+        @if($step < 3)
+          <button type="button" class="btn-primary bg-gradient-to-r from-violet-500 to-fuchsia-500" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="next">Avanti</span>
+            <span wire:loading wire:target="next">Controllo dati…</span>
+          </button>
+        @else
+          <button type="button" class="btn-primary bg-gradient-to-r from-violet-500 to-fuchsia-500" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="conferma">Conferma</span>
+            <span wire:loading wire:target="conferma">Salvataggio…</span>
+          </button>
+        @endif
+      </div>
     </div>
   </div>
-
-  <div class="flex items-center gap-2 text-sm">
-    @php($labels = $fase === 'invio' ? [1=>'Dati invio',2=>'Articoli',3=>'Riepilogo'] : [1=>'Ordine e magazzino',2=>'Quantità rientro',3=>'Riepilogo'])
-    @foreach ($labels as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-violet-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
-
-  @if($fase === 'invio')
-    @if($step === 1)
-      <div class="card space-y-4">
-        <div>
-          <label class="block text-sm font-medium">Terzista</label>
-          <select wire:model="invio.terzista_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($terzisti as $t)
-              <option value="{{ $t->id }}">{{ $t->ragione_sociale }}</option>
-            @endforeach
-          </select>
-          @error('invio.terzista_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Magazzino di uscita</label>
-            <select wire:model="invio.magazzino_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($magazzini as $m)
-                <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-              @endforeach
-            </select>
-            @error('invio.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Ubicazione</label>
-            <select wire:model="invio.ubicazione_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($ubicazioniInvio as $u)
-                <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-              @endforeach
-            </select>
-            @error('invio.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm">Data invio</label>
-            <input type="date" wire:model="invio.data_invio" class="w-full border rounded-xl p-2" />
-            @error('invio.data_invio')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm">Data rientro prevista</label>
-            <input type="date" wire:model="invio.data_rientro_prevista" class="w-full border rounded-xl p-2" />
-            @error('invio.data_rientro_prevista')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-        </div>
-        <div>
-          <label class="block text-sm">Note per il terzista</label>
-          <textarea wire:model.lazy="invio.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Indicazioni, componenti, urgenze..."></textarea>
-        </div>
-      </div>
-    @endif
-
-    @if($step === 2)
-      <div class="card space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="font-medium">Articoli da inviare</h2>
-          <button type="button" class="btn-secondary" wire:click="addRiga">+ Aggiungi riga</button>
-        </div>
-        @foreach($righe as $i => $riga)
-          <div class="grid grid-cols-1 lg:grid-cols-12 gap-3 items-end">
-            <div class="lg:col-span-5">
-              <label class="block text-sm">Articolo</label>
-              <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-                <option value="">— seleziona —</option>
-                @foreach($articoli as $a)
-                  <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
-                @endforeach
-              </select>
-              @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-            </div>
-            <div class="lg:col-span-2">
-              <label class="block text-sm">Q.tà</label>
-              <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-              @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-            </div>
-            <div class="lg:col-span-2">
-              <label class="block text-sm">Lotto</label>
-              <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-            </div>
-            <div class="lg:col-span-3">
-              <label class="block text-sm">Componenti / lavorazioni</label>
-              <input type="text" wire:model.lazy="righe.{{ $i }}.componenti" class="w-full border rounded-xl p-2" placeholder="Es. fodera, bottoni..." />
-            </div>
-          </div>
-          <hr class="border-dashed">
-        @endforeach
-      </div>
-    @endif
-
-    @if($step === 3)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Riepilogo invio</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-          <div>
-            <div class="font-semibold">Terzista</div>
-            <div>{{ $riepilogo['terzista'] ?? '—' }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Magazzino</div>
-            <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-            @if($riepilogo['ubicazione'] ?? false)
-              <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-            @endif
-          </div>
-          <div>
-            <div class="font-semibold">Data invio</div>
-            <div>{{ $invio['data_invio'] }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Rientro previsto</div>
-            <div>{{ $invio['data_rientro_prevista'] ?: '—' }}</div>
-          </div>
-        </div>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Articolo</th>
-                <th class="text-right">Q.tà</th>
-                <th class="text-left">Lotto</th>
-                <th class="text-left">Componenti</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($riepilogo['righe'] ?? [] as $r)
-                <tr class="border-b">
-                  <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                  <td class="text-right">{{ $r['qta'] }}</td>
-                  <td>{{ $r['lotto'] ?: '—' }}</td>
-                  <td>{{ $r['componenti'] ?: '—' }}</td>
-                </tr>
-              @endforeach
-            </tbody>
-          </table>
-        </div>
-      </div>
-    @endif
-  @else
-    @if($step === 1)
-      <div class="card space-y-4">
-        <div>
-          <label class="block text-sm font-medium">Ordine conto lavoro</label>
-          <select wire:model="rientro.ordine_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ordiniAperti as $ordine)
-              <option value="{{ $ordine->id }}">#{{ $ordine->id }} — {{ $ordine->terzista?->ragione_sociale }} ({{ $ordine->stato }})</option>
-            @endforeach
-          </select>
-          @error('rientro.ordine_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Magazzino di rientro</label>
-            <select wire:model="rientro.magazzino_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($magazzini as $m)
-                <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-              @endforeach
-            </select>
-            @error('rientro.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Ubicazione</label>
-            <select wire:model="rientro.ubicazione_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($ubicazioniRientro as $u)
-                <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-              @endforeach
-            </select>
-            @error('rientro.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-        </div>
-        <div>
-          <label class="block text-sm">Note interne</label>
-          <textarea wire:model.lazy="rientro.note" rows="3" class="w-full border rounded-xl p-2"></textarea>
-        </div>
-      </div>
-    @endif
-
-    @if($step === 2)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Quantità da rientrare</h2>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Riga</th>
-                <th class="text-right">Inviato</th>
-                <th class="text-right">Disponibile</th>
-                <th class="text-right">Rientro</th>
-                <th class="text-right">Scarto</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($rientroRighe as $i => $riga)
-                <tr class="border-b">
-                  <td class="py-2">
-                    <div>{{ $riga['articolo'] }}</div>
-                    @if($riga['lotto'])<div class="text-xs text-slate-500">Lotto: {{ $riga['lotto'] }}</div>@endif
-                  </td>
-                  <td class="text-right">{{ $riga['qta_inviata'] }}</td>
-                  <td class="text-right">{{ $riga['disponibile'] }}</td>
-                  <td class="text-right">
-                    <input type="number" step="0.001" min="0" max="{{ $riga['disponibile'] }}" wire:model.lazy="rientroRighe.{{ $i }}.qta_rientro" class="w-full border rounded-xl p-1.5" />
-                    @error("rientroRighe.$i.qta_rientro")<p class="text-xs text-red-600">{{ $message }}</p>@enderror
-                  </td>
-                  <td class="text-right">
-                    <input type="number" step="0.001" min="0" wire:model.lazy="rientroRighe.{{ $i }}.scarto" class="w-full border rounded-xl p-1.5" />
-                    @error("rientroRighe.$i.scarto")<p class="text-xs text-red-600">{{ $message }}</p>@enderror
-                  </td>
-                </tr>
-              @endforeach
-            </tbody>
-          </table>
-        </div>
-      </div>
-    @endif
-
-    @if($step === 3)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Riepilogo rientro</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-          <div>
-            <div class="font-semibold">Ordine</div>
-            <div>#{{ $riepilogo['ordine'] ?? '—' }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Magazzino</div>
-            <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-            @if($riepilogo['ubicazione'] ?? false)
-              <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-            @endif
-          </div>
-          <div>
-            <div class="font-semibold">Terzista</div>
-            <div>{{ $riepilogo['terzista'] ?? '—' }}</div>
-          </div>
-        </div>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Articolo</th>
-                <th class="text-right">Rientro</th>
-                <th class="text-right">Scarto</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($rientroRighe as $r)
-                @if((float)($r['qta_rientro'] ?? 0) > 0 || (float)($r['scarto'] ?? 0) > 0)
-                  <tr class="border-b">
-                    <td class="py-2">{{ $r['articolo'] }}</td>
-                    <td class="text-right">{{ $r['qta_rientro'] }}</td>
-                    <td class="text-right">{{ $r['scarto'] }}</td>
-                  </tr>
-                @endif
-              @endforeach
-            </tbody>
-          </table>
-        </div>
-      </div>
-    @endif
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
-  </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/resources/views/livewire/movimenti/scarico-wizard.blade.php
+++ b/resources/views/livewire/movimenti/scarico-wizard.blade.php
@@ -1,182 +1,231 @@
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Prelievo / Reso magazzino</h1>
-
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Contesto',2=>'Articoli',3=>'Riepilogo'] as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-amber-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
-
-  @if($step === 1)
-    <div class="card space-y-4">
-      <div class="flex items-center gap-3">
-        <label class="text-sm font-medium">Operazione</label>
-        <div class="flex items-center gap-2">
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input type="radio" wire:model="contesto.tipo" value="prelievo" class="accent-brand-600">
-            <span>Prelievo</span>
-          </label>
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input type="radio" wire:model="contesto.tipo" value="reso" class="accent-brand-600">
-            <span>Reso</span>
-          </label>
+<div class="mx-auto max-w-6xl px-4 py-6">
+  <div class="wizard-frame wizard-grid-overlay">
+    <div class="wizard-surface" wire:key="scarico-step-shell">
+      <div class="wizard-hero">
+        <div class="space-y-3">
+          <span class="wizard-hero-badge bg-rose-100 text-rose-700">Scarico / Reso</span>
+          <h1 class="text-3xl font-semibold text-slate-900">Gestisci il prelievo di filati con uno stile da sartoria digitale</h1>
+          <p class="text-sm text-slate-600 leading-relaxed">
+            Scegli il magazzino di origine, indica l'operatore e specifica gli articoli da movimentare.
+            L'interfaccia ottimizzata permette di lavorare rapidamente anche da tablet o smartphone.
+          </p>
+        </div>
+        <div class="hidden lg:block">
+          <img src="{{ asset('images/loom-weave.svg') }}" alt="Telaio stilizzato" class="h-48 w-auto drop-shadow-xl" />
         </div>
       </div>
-      @error('contesto.tipo')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
 
-      <div>
-        <label class="block text-sm font-medium">Magazzino</label>
-        <select wire:model="contesto.magazzino_id" class="w-full border rounded-xl p-2">
-          <option value="">— seleziona —</option>
-          @foreach($magazzini as $m)
-            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+      @php
+        $wizardSteps = [
+          1 => 'Dati prelievo',
+          2 => 'Articoli',
+          3 => 'Riepilogo',
+        ];
+      @endphp
+
+      <div class="wizard-stepper">
+        <ol>
+          @foreach($wizardSteps as $i => $label)
+            <li>
+              <div class="wizard-step-indicator {{ $step >= $i ? 'border-rose-500 bg-rose-500 text-white shadow-lg shadow-rose-200/80' : 'border-slate-200 bg-white text-slate-500' }}">
+                {{ $i }}
+              </div>
+              <div class="flex flex-col">
+                <span class="font-semibold {{ $step >= $i ? 'text-slate-900' : 'text-slate-500' }}">{{ $label }}</span>
+                <span class="text-xs text-slate-400">Passo {{ $i }} di {{ count($wizardSteps) }}</span>
+              </div>
+            </li>
           @endforeach
-        </select>
-        @error('contesto.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </ol>
       </div>
 
-      @if($ubicazioni->isNotEmpty())
-        <div>
-          <label class="block text-sm font-medium">Ubicazione</label>
-          <select wire:model="contesto.ubicazione_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ubicazioni as $u)
-              <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-            @endforeach
-          </select>
-          @error('contesto.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-      @elseif($contesto['magazzino_id'])
-        <p class="text-xs text-slate-500">Non ci sono ubicazioni attive per il magazzino selezionato.</p>
+      @if ($errors->has('general'))
+        <div class="wizard-error">{{ $errors->first('general') }}</div>
+      @endif
+      @if (session('ok'))
+        <div class="wizard-success">{{ session('ok') }}</div>
       @endif
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm">Operatore</label>
-          <input type="text" wire:model.lazy="contesto.operatore" class="w-full border rounded-xl p-2" />
-          @error('contesto.operatore')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Commessa</label>
-          <input type="text" wire:model.lazy="contesto.commessa" class="w-full border rounded-xl p-2" />
-        </div>
-        <div>
-          <label class="block text-sm">Destinatario / Reparto</label>
-          <input type="text" wire:model.lazy="contesto.destinatario" class="w-full border rounded-xl p-2" placeholder="Es. sartoria, terzista..." />
-        </div>
-      </div>
+      <div class="space-y-8" wire:key="scarico-step-{{ $step }}">
+        @if($step === 1)
+          <div class="wizard-panel">
+            <div class="grid gap-5 lg:grid-cols-2">
+              <div class="space-y-4">
+                <div class="flex flex-col gap-2">
+                  <label class="block text-sm font-medium text-slate-700">Tipologia movimento</label>
+                  <div class="flex gap-2">
+                    <label class="flex-1 cursor-pointer rounded-2xl border border-rose-200 bg-white/80 px-3 py-2 text-center text-sm font-medium {{ $contesto['tipo']==='prelievo' ? 'ring-2 ring-rose-400 text-rose-700' : 'text-slate-600' }}">
+                      <input type="radio" class="hidden" value="prelievo" wire:model.live="contesto.tipo" />
+                      Prelievo interno
+                    </label>
+                    <label class="flex-1 cursor-pointer rounded-2xl border border-emerald-200 bg-white/80 px-3 py-2 text-center text-sm font-medium {{ $contesto['tipo']==='reso' ? 'ring-2 ring-emerald-400 text-emerald-700' : 'text-slate-600' }}">
+                      <input type="radio" class="hidden" value="reso" wire:model.live="contesto.tipo" />
+                      Reso materiale
+                    </label>
+                  </div>
+                  @error('contesto.tipo')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
 
-      <div>
-        <label class="block text-sm">Note</label>
-        <textarea wire:model.lazy="contesto.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Dettagli aggiuntivi"></textarea>
-      </div>
-    </div>
-  @endif
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-700">Magazzino di origine</label>
+                  <select wire:model.live="contesto.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500">
+                    <option value="">— seleziona —</option>
+                    @foreach($magazzini as $m)
+                      <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                    @endforeach
+                  </select>
+                  @error('contesto.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
 
-  @if($step === 2)
-    <div class="card space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="font-medium">Articoli movimentati</h2>
-        <button type="button" wire:click="addRiga" class="btn-secondary">+ Aggiungi riga</button>
-      </div>
+                @if($ubicazioni->isNotEmpty())
+                  <div class="space-y-2">
+                    <label class="block text-sm font-medium text-slate-700">Ubicazione</label>
+                    <select wire:model.live="contesto.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500">
+                      <option value="">— seleziona —</option>
+                      @foreach($ubicazioni as $u)
+                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                      @endforeach
+                    </select>
+                    @error('contesto.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                @elseif($contesto['magazzino_id'])
+                  <p class="text-xs text-slate-500">Nessuna ubicazione attiva per questo magazzino.</p>
+                @endif
+              </div>
 
-      @foreach($righe as $i => $riga)
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-end">
-          <div class="md:col-span-6">
-            <label class="block text-sm">Articolo</label>
-            <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($articoli as $a)
-                <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+              <div class="space-y-4">
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Operatore</label>
+                    <input type="text" wire:model.live="contesto.operatore" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" placeholder="Nome operatore" />
+                    @error('contesto.operatore')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Commessa / Rif.</label>
+                    <input type="text" wire:model.live="contesto.commessa" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" />
+                    @error('contesto.commessa')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-700">Destinatario</label>
+                    <input type="text" wire:model.live="contesto.destinatario" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" />
+                    @error('contesto.destinatario')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                  </div>
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-slate-700">Note</label>
+                  <textarea wire:model.live="contesto.note" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" placeholder="Specifiche per il magazzino..."></textarea>
+                  @error('contesto.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                </div>
+              </div>
+            </div>
+          </div>
+        @endif
+
+        @if($step === 2)
+          <div class="wizard-panel space-y-6">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h2>Articoli in uscita</h2>
+                <p class="text-sm text-slate-500">Indica filati, tessuti o accessori prelevati dal magazzino.</p>
+              </div>
+              <button type="button" wire:click="addRiga" class="inline-flex items-center gap-2 rounded-full bg-rose-100 px-4 py-2 text-sm font-medium text-rose-700 shadow-sm transition hover:bg-rose-200">
+                <span class="text-lg">＋</span> Aggiungi riga
+              </button>
+            </div>
+
+            <div class="space-y-5">
+              @foreach($righe as $i => $riga)
+                <div class="rounded-3xl border border-rose-100/80 bg-white/90 p-5 shadow-inner" wire:key="scarico-riga-{{ $i }}">
+                  <div class="grid gap-4 md:grid-cols-12 md:items-end">
+                    <div class="md:col-span-6">
+                      <label class="block text-sm font-medium text-slate-700">Articolo</label>
+                      <select wire:model.live="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500">
+                        <option value="">— seleziona —</option>
+                        @foreach($articoli as $a)
+                          <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                        @endforeach
+                      </select>
+                      @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-3">
+                      <label class="block text-sm font-medium text-slate-700">Q.tà</label>
+                      <input type="number" step="0.001" min="0" wire:model.live="righe.{{ $i }}.qta" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" />
+                      @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-2">
+                      <label class="block text-sm font-medium text-slate-700">Lotto</label>
+                      <input type="text" wire:model.live="righe.{{ $i }}.lotto" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-rose-500 focus:ring-rose-500" />
+                    </div>
+                    <div class="md:col-span-1">
+                      <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-100">🗑️</button>
+                    </div>
+                  </div>
+                </div>
               @endforeach
-            </select>
-            @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
           </div>
-          <div class="md:col-span-3">
-            <label class="block text-sm">Q.tà</label>
-            <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-2">
-            <label class="block text-sm">Lotto (se presente)</label>
-            <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-          </div>
-          <div class="md:col-span-1">
-            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-xl p-2 hover:bg-red-50">🗑️</button>
-          </div>
-        </div>
-        <hr class="border-dashed">
-      @endforeach
-    </div>
-  @endif
+        @endif
 
-  @if($step === 3)
-    <div class="card space-y-4">
-      <h2 class="font-medium">Riepilogo</h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div>
-          <div class="font-semibold">Operazione</div>
-          <div class="uppercase tracking-wide text-xs font-semibold"><x-ui.badge color="amber">{{ strtoupper($contesto['tipo']) }}</x-ui.badge></div>
-        </div>
-        <div>
-          <div class="font-semibold">Magazzino</div>
-          <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-          @if($riepilogo['ubicazione'] ?? false)
-            <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-          @endif
-        </div>
-        <div>
-          <div class="font-semibold">Operatore</div>
-          <div>{{ $contesto['operatore'] }}</div>
-        </div>
-        <div>
-          <div class="font-semibold">Commessa</div>
-          <div>{{ $contesto['commessa'] ?: '—' }}</div>
-        </div>
+        @if($step === 3)
+          <div class="wizard-panel space-y-6">
+            <div>
+              <h2>Riepilogo movimento</h2>
+              <p class="text-sm text-slate-500">Controlla le informazioni prima di registrare lo scarico.</p>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2 text-sm">
+              <div class="rounded-2xl border border-rose-100/70 bg-rose-50/60 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-rose-600">Magazzino</div>
+                <div class="text-base font-semibold text-slate-800">{{ $riepilogo['magazzino'] ?? '—' }}</div>
+                @if($riepilogo['ubicazione'] ?? false)
+                  <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
+                @endif
+              </div>
+              <div class="rounded-2xl border border-slate-200 bg-white/70 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Operatore</div>
+                <div class="text-base font-semibold text-slate-800">{{ $contesto['operatore'] }}</div>
+                <div class="text-xs text-slate-500">Destinatario: {{ $contesto['destinatario'] ?: '—' }}</div>
+              </div>
+            </div>
+            <div class="overflow-hidden rounded-3xl border border-slate-200/60">
+              <table class="min-w-full divide-y divide-slate-200 text-sm">
+                <thead class="bg-slate-50/60">
+                  <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Articolo</th>
+                    <th class="px-4 py-3 text-right font-semibold text-slate-600">Q.tà</th>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Lotto</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-100 bg-white/80">
+                  @foreach($riepilogo['righe'] ?? [] as $r)
+                    <tr>
+                      <td class="px-4 py-3">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                      <td class="px-4 py-3 text-right font-medium text-slate-700">{{ $r['qta'] }}</td>
+                      <td class="px-4 py-3 text-slate-500">{{ $r['lotto'] ?: '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          </div>
+        @endif
       </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="text-left py-2">Articolo</th>
-              <th class="text-right">Q.tà</th>
-              <th class="text-left">Lotto</th>
-            </tr>
-          </thead>
-          <tbody>
-            @foreach($riepilogo['righe'] ?? [] as $r)
-              <tr class="border-b">
-                <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                <td class="text-right">{{ $r['qta'] }}</td>
-                <td>{{ $r['lotto'] ?: '—' }}</td>
-              </tr>
-            @endforeach
-          </tbody>
-        </table>
+
+      <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        <button type="button" class="btn-secondary" wire:click="back" wire:target="back" wire:loading.attr="disabled" @disabled($step===1)>
+          Indietro
+        </button>
+        @if($step < 3)
+          <button type="button" class="btn-primary bg-gradient-to-r from-rose-500 to-rose-600" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="next">Avanti</span>
+            <span wire:loading wire:target="next">Controllo dati…</span>
+          </button>
+        @else
+          <button type="button" class="btn-primary bg-gradient-to-r from-rose-500 to-rose-600" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="conferma">Conferma movimento</span>
+            <span wire:loading wire:target="conferma">Salvataggio…</span>
+          </button>
+        @endif
       </div>
     </div>
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma operazione</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
   </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/resources/views/livewire/movimenti/transfer-wizard.blade.php
+++ b/resources/views/livewire/movimenti/transfer-wizard.blade.php
@@ -1,168 +1,218 @@
-{{-- resources/views/livewire/movimenti/transfer-wizard.blade.php --}}
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Trasferimento tra magazzini</h1>
-
-  {{-- Stepper --}}
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Origine',2=>'Destinazione',3=>'Articoli',4=>'Riepilogo',5=>'Conferma'] as $i=>$label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-blue-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i<5)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
-
-  {{-- Step 1: Origine --}}
-  @if($step===1)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-3">
-    <label class="block text-sm font-medium">Magazzino di origine</label>
-    <select wire:model="origine.magazzino_id" class="w-full border rounded-lg p-2">
-      <option value="">— seleziona —</option>
-      @foreach($magazzini as $m)
-        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-      @endforeach
-    </select>
-    @error('origine.magazzino_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-
-    @if($origineUbicazioni->isNotEmpty())
-      <label class="block text-sm font-medium">Ubicazione di origine</label>
-      <select wire:model="origine.ubicazione_id" class="w-full border rounded-lg p-2">
-        <option value="">— seleziona —</option>
-        @foreach($origineUbicazioni as $u)
-          <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-        @endforeach
-      </select>
-      @error('origine.ubicazione_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @elseif($origine['magazzino_id'])
-      <p class="text-xs text-slate-500">Questo magazzino non ha ubicazioni attive: il trasferimento userà l'intero magazzino.</p>
-    @endif
-  </div>
-  @endif
-
-  {{-- Step 2: Destinazione --}}
-  @if($step===2)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-3">
-    <label class="block text-sm font-medium">Magazzino di destinazione</label>
-    <select wire:model="destinazione.magazzino_id" class="w-full border rounded-lg p-2">
-      <option value="">— seleziona —</option>
-      @foreach($magazzini as $m)
-        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-      @endforeach
-    </select>
-    @error('destinazione.magazzino_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @if($destinazioneUbicazioni->isNotEmpty())
-      <label class="block text-sm font-medium">Ubicazione di destinazione</label>
-      <select wire:model="destinazione.ubicazione_id" class="w-full border rounded-lg p-2">
-        <option value="">— seleziona —</option>
-        @foreach($destinazioneUbicazioni as $u)
-          <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-        @endforeach
-      </select>
-      @error('destinazione.ubicazione_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @elseif($destinazione['magazzino_id'])
-      <p class="text-xs text-slate-500">Non sono presenti ubicazioni attive per il magazzino scelto.</p>
-    @endif
-  </div>
-  @endif
-
-  {{-- Step 3: Articoli --}}
-  @if($step===3)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-4">
-    <div class="flex justify-between items-center">
-      <h2 class="font-medium">Articoli da trasferire</h2>
-      <button wire:click="addRiga" type="button" class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200">+ Aggiungi riga</button>
-    </div>
-    @foreach($righe as $i => $r)
-      <div class="grid grid-cols-1 md:grid-cols-12 gap-2 items-end">
-        <div class="md:col-span-6">
-          <label class="block text-sm">Articolo</label>
-          <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-lg p-2">
-            <option value="">— seleziona —</option>
-            @foreach($articoli as $a)
-              <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
-            @endforeach
-          </select>
-          @error("righe.$i.articolo_id")<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
+<div class="mx-auto max-w-6xl px-4 py-6">
+  <div class="wizard-frame wizard-grid-overlay">
+    <div class="wizard-surface" wire:key="transfer-step-shell">
+      <div class="wizard-hero">
+        <div class="space-y-3">
+          <span class="wizard-hero-badge bg-sky-100 text-sky-700">Trasferimento</span>
+          <h1 class="text-3xl font-semibold text-slate-900">Sincronizza i magazzini con un trasferimento dal design tessile</h1>
+          <p class="text-sm text-slate-600 leading-relaxed">
+            Sposta filati e accessori fra reparti e stabilimenti con step guidati.
+            Ogni sezione ti mostra solo le informazioni necessarie per evitare errori.
+          </p>
         </div>
-        <div class="md:col-span-3">
-          <label class="block text-sm">Q.tà</label>
-          <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-lg p-2" />
-          @error("righe.$i.qta")<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-        </div>
-        <div class="md:col-span-2">
-          <label class="block text-sm">Lotto (opz.)</label>
-          <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-lg p-2" />
-        </div>
-        <div class="md:col-span-1">
-          <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-lg p-2 hover:bg-red-50">🗑️</button>
+        <div class="hidden lg:block">
+          <img src="{{ asset('images/warehouse-racks.svg') }}" alt="Magazzino stilizzato" class="h-48 w-auto drop-shadow-xl" />
         </div>
       </div>
-      <hr class="my-2">
-    @endforeach
-  </div>
-  @endif
 
-  {{-- Step 4: Riepilogo --}}
-  @if($step===4)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-4">
-    <p class="text-sm">Controlla i dati e procedi alla conferma.</p>
-    <ul class="text-sm space-y-1">
-      <li>
-        <strong>Origine:</strong>
-        {{ optional($magazzini->firstWhere('id', $origine['magazzino_id']))?->descrizione }}
-        @if(!empty($riepilogo['origine']['ubicazione_label']))
-          <span class="block text-xs text-slate-500">Ubicazione: {{ $riepilogo['origine']['ubicazione_label'] }}</span>
-        @endif
-      </li>
-      <li>
-        <strong>Destinazione:</strong>
-        {{ optional($magazzini->firstWhere('id', $destinazione['magazzino_id']))?->descrizione }}
-        @if(!empty($riepilogo['destinazione']['ubicazione_label']))
-          <span class="block text-xs text-slate-500">Ubicazione: {{ $riepilogo['destinazione']['ubicazione_label'] }}</span>
-        @endif
-      </li>
-    </ul>
-    <div class="overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead><tr class="border-b">
-          <th class="text-left py-2">Articolo</th><th class="text-right">Q.tà</th><th class="text-left">Lotto</th>
-        </tr></thead>
-        <tbody>
-          @foreach($riepilogo['righe'] ?? [] as $r)
-            <tr class="border-b">
-              <td class="py-2">{{ $r['codice'] }} — {{ $r['descr'] }}</td>
-              <td class="text-right">{{ $r['qta'] }}</td>
-              <td>{{ $r['lotto'] }}</td>
-            </tr>
+      @php
+        $wizardSteps = [
+          1 => 'Origine',
+          2 => 'Destinazione',
+          3 => 'Articoli',
+          4 => 'Riepilogo',
+        ];
+      @endphp
+
+      <div class="wizard-stepper">
+        <ol>
+          @foreach($wizardSteps as $i => $label)
+            <li>
+              <div class="wizard-step-indicator {{ $step >= $i ? 'border-sky-500 bg-sky-500 text-white shadow-lg shadow-sky-200/80' : 'border-slate-200 bg-white text-slate-500' }}">
+                {{ $i }}
+              </div>
+              <div class="flex flex-col">
+                <span class="font-semibold {{ $step >= $i ? 'text-slate-900' : 'text-slate-500' }}">{{ $label }}</span>
+                <span class="text-xs text-slate-400">Passo {{ $i }} di {{ count($wizardSteps) }}</span>
+              </div>
+            </li>
           @endforeach
-        </tbody>
-      </table>
+        </ol>
+      </div>
+
+      @if ($errors->has('general'))
+        <div class="wizard-error">{{ $errors->first('general') }}</div>
+      @endif
+      @if (session('ok'))
+        <div class="wizard-success">{{ session('ok') }}</div>
+      @endif
+
+      <div class="space-y-8" wire:key="transfer-step-{{ $step }}">
+        @if($step === 1)
+          <div class="wizard-panel">
+            <h2>Magazzino di origine</h2>
+            <p class="text-sm text-slate-500">Seleziona dove si trovano attualmente i materiali da trasferire.</p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="space-y-2">
+                <label class="block text-sm font-medium text-slate-700">Magazzino</label>
+                <select wire:model.live="origine.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500">
+                  <option value="">— seleziona —</option>
+                  @foreach($magazzini as $m)
+                    <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                  @endforeach
+                </select>
+                @error('origine.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+              <div class="space-y-2">
+                <label class="block text-sm font-medium text-slate-700">Ubicazione</label>
+                <select wire:model.live="origine.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500">
+                  <option value="">— seleziona —</option>
+                  @foreach($origineUbicazioni as $u)
+                    <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                  @endforeach
+                </select>
+                @error('origine.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+            </div>
+          </div>
+        @endif
+
+        @if($step === 2)
+          <div class="wizard-panel">
+            <h2>Magazzino di destinazione</h2>
+            <p class="text-sm text-slate-500">Definisci dove verranno collocati i materiali in arrivo.</p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="space-y-2">
+                <label class="block text-sm font-medium text-slate-700">Magazzino</label>
+                <select wire:model.live="destinazione.magazzino_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500">
+                  <option value="">— seleziona —</option>
+                  @foreach($magazzini as $m)
+                    <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                  @endforeach
+                </select>
+                @error('destinazione.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+              <div class="space-y-2">
+                <label class="block text-sm font-medium text-slate-700">Ubicazione</label>
+                <select wire:model.live="destinazione.ubicazione_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500">
+                  <option value="">— seleziona —</option>
+                  @foreach($destinazioneUbicazioni as $u)
+                    <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                  @endforeach
+                </select>
+                @error('destinazione.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+              </div>
+            </div>
+          </div>
+        @endif
+
+        @if($step === 3)
+          <div class="wizard-panel space-y-6">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h2>Articoli da trasferire</h2>
+                <p class="text-sm text-slate-500">Aggiungi righe con quantità e lotti per tracciare lo spostamento.</p>
+              </div>
+              <button type="button" wire:click="addRiga" class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-2 text-sm font-medium text-sky-700 shadow-sm transition hover:bg-sky-200">
+                <span class="text-lg">＋</span> Aggiungi riga
+              </button>
+            </div>
+
+            <div class="space-y-5">
+              @foreach($righe as $i => $riga)
+                <div class="rounded-3xl border border-sky-100/80 bg-white/90 p-5 shadow-inner" wire:key="transfer-riga-{{ $i }}">
+                  <div class="grid gap-4 md:grid-cols-12 md:items-end">
+                    <div class="md:col-span-6">
+                      <label class="block text-sm font-medium text-slate-700">Articolo</label>
+                      <select wire:model.live="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500">
+                        <option value="">— seleziona —</option>
+                        @foreach($articoli as $a)
+                          <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                        @endforeach
+                      </select>
+                      @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-3">
+                      <label class="block text-sm font-medium text-slate-700">Q.tà</label>
+                      <input type="number" step="0.001" min="0" wire:model.live="righe.{{ $i }}.qta" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500" />
+                      @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div class="md:col-span-2">
+                      <label class="block text-sm font-medium text-slate-700">Lotto</label>
+                      <input type="text" wire:model.live="righe.{{ $i }}.lotto" class="w-full rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-inner focus:border-sky-500 focus:ring-sky-500" />
+                    </div>
+                    <div class="md:col-span-1">
+                      <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-100">🗑️</button>
+                    </div>
+                  </div>
+                </div>
+              @endforeach
+            </div>
+          </div>
+        @endif
+
+        @if($step === 4)
+          <div class="wizard-panel space-y-6">
+            <div>
+              <h2>Riepilogo trasferimento</h2>
+              <p class="text-sm text-slate-500">Controlla origine, destinazione e righe prima di confermare.</p>
+            </div>
+            <div class="grid gap-4 md:grid-cols-2 text-sm">
+              <div class="rounded-2xl border border-sky-100/70 bg-sky-50/60 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-sky-600">Origine</div>
+                <div class="text-base font-semibold text-slate-800">{{ optional($magazzini->firstWhere('id', $origine['magazzino_id']))?->descrizione }}</div>
+                @if(!empty($riepilogo['origine']['ubicazione_label']))
+                  <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['origine']['ubicazione_label'] }}</div>
+                @endif
+              </div>
+              <div class="rounded-2xl border border-emerald-100/70 bg-emerald-50/60 p-4">
+                <div class="text-xs font-semibold uppercase tracking-wide text-emerald-600">Destinazione</div>
+                <div class="text-base font-semibold text-slate-800">{{ optional($magazzini->firstWhere('id', $destinazione['magazzino_id']))?->descrizione }}</div>
+                @if(!empty($riepilogo['destinazione']['ubicazione_label']))
+                  <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['destinazione']['ubicazione_label'] }}</div>
+                @endif
+              </div>
+            </div>
+            <div class="overflow-hidden rounded-3xl border border-slate-200/60">
+              <table class="min-w-full divide-y divide-slate-200 text-sm">
+                <thead class="bg-slate-50/60">
+                  <tr>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Articolo</th>
+                    <th class="px-4 py-3 text-right font-semibold text-slate-600">Q.tà</th>
+                    <th class="px-4 py-3 text-left font-semibold text-slate-600">Lotto</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-100 bg-white/80">
+                  @foreach($riepilogo['righe'] ?? [] as $r)
+                    <tr>
+                      <td class="px-4 py-3">{{ $r['codice'] }} — {{ $r['descr'] }}</td>
+                      <td class="px-4 py-3 text-right font-medium text-slate-700">{{ $r['qta'] }}</td>
+                      <td class="px-4 py-3 text-slate-500">{{ $r['lotto'] ?? '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          </div>
+        @endif
+      </div>
+
+      <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        <button type="button" class="btn-secondary" wire:click="back" wire:target="back" wire:loading.attr="disabled" @disabled($step===1)>
+          Indietro
+        </button>
+        @if($step < 4)
+          <button type="button" class="btn-primary bg-gradient-to-r from-sky-500 to-sky-600" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="next">Avanti</span>
+            <span wire:loading wire:target="next">Controllo dati…</span>
+          </button>
+        @else
+          <button type="button" class="btn-primary bg-gradient-to-r from-sky-500 to-sky-600" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="conferma">Conferma trasferimento</span>
+            <span wire:loading wire:target="conferma">Salvataggio…</span>
+          </button>
+        @endif
+      </div>
     </div>
   </div>
-  @endif
-
-  {{-- Navigazione --}}
-  <div class="flex justify-between">
-    <button type="button" wire:click="back" @disabled($step===1)
-      class="px-4 py-2 rounded-lg border">Indietro</button>
-
-    @if($step<4)
-      <button type="button" wire:click="next" class="px-4 py-2 rounded-lg bg-blue-600 text-white">Avanti</button>
-    @elseif($step===4)
-    <button type="button" wire:click="conferma" wire:loading.attr="disabled" class="px-4 py-2 rounded-lg bg-green-600 text-white">
-        <span wire:loading.remove>Conferma trasferimento</span>
-        <span wire:loading>Salvo…</span>
-    </button>
-
-    @endif
-  </div>
-  @if ($errors->has('general'))
-  <div class="p-3 rounded-lg bg-red-50 text-red-800 mt-3">
-    {{ $errors->first('general') }}
-  </div>
-@endif
-  @if (session('ok'))
-    <div class="p-3 rounded-lg bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/tests/Feature/Livewire/MovimentiWizardsTest.php
+++ b/tests/Feature/Livewire/MovimentiWizardsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Movimenti\CaricoWizard;
+use App\Livewire\Movimenti\ContoLavoroWizard;
+use App\Livewire\Movimenti\ScaricoWizard;
+use App\Livewire\Movimenti\TransferWizard;
+use App\Models\Articolo;
+use App\Models\Magazzino;
+use App\Models\Terzista;
+use App\Models\Ubicazione;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class MovimentiWizardsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_carico_wizard_advances_only_with_valid_data(): void
+    {
+        $magazzino = Magazzino::factory()->create();
+        $ubicazione = Ubicazione::factory()->create(['magazzino_id' => $magazzino->id]);
+        $articolo = Articolo::factory()->create();
+
+        $component = Livewire::test(CaricoWizard::class);
+
+        $component->call('next')
+            ->assertHasErrors(['contesto.magazzino_id'])
+            ->assertSet('step', 1);
+
+        $component
+            ->set('contesto.magazzino_id', $magazzino->id)
+            ->set('contesto.ubicazione_id', $ubicazione->id)
+            ->call('next')
+            ->assertSet('step', 2);
+
+        $component
+            ->set('righe.0.articolo_id', $articolo->id)
+            ->set('righe.0.qta', '12.5')
+            ->set('righe.0.lotto', 'LOT-1')
+            ->call('next')
+            ->assertSet('step', 3);
+    }
+
+    public function test_scarico_wizard_handles_validation_and_progress(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $magazzino = Magazzino::factory()->create();
+        $ubicazione = Ubicazione::factory()->create(['magazzino_id' => $magazzino->id]);
+        $articolo = Articolo::factory()->create();
+
+        $component = Livewire::test(ScaricoWizard::class)
+            ->set('contesto.tipo', 'prelievo')
+            ->set('contesto.magazzino_id', $magazzino->id)
+            ->set('contesto.ubicazione_id', $ubicazione->id)
+            ->set('contesto.operatore', 'Tester Operatore');
+
+        $component->call('next')
+            ->assertSet('step', 2);
+
+        $component
+            ->set('righe.0.articolo_id', $articolo->id)
+            ->set('righe.0.qta', '3')
+            ->call('next')
+            ->assertSet('step', 3);
+    }
+
+    public function test_transfer_wizard_advances_through_steps(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $origineMag = Magazzino::factory()->create();
+        $destMag = Magazzino::factory()->create();
+        $origineUbic = Ubicazione::factory()->create(['magazzino_id' => $origineMag->id]);
+        $destUbic = Ubicazione::factory()->create(['magazzino_id' => $destMag->id]);
+        $articolo = Articolo::factory()->create();
+
+        $component = Livewire::test(TransferWizard::class)
+            ->set('origine.magazzino_id', $origineMag->id)
+            ->set('origine.ubicazione_id', $origineUbic->id)
+            ->call('next')
+            ->assertSet('step', 2)
+            ->set('destinazione.magazzino_id', $destMag->id)
+            ->set('destinazione.ubicazione_id', $destUbic->id)
+            ->call('next')
+            ->assertSet('step', 3);
+
+        $component
+            ->set('righe.0.articolo_id', $articolo->id)
+            ->set('righe.0.qta', '8')
+            ->call('next')
+            ->assertSet('step', 4);
+    }
+
+    public function test_conto_lavoro_invio_flow_advances(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $terzista = Terzista::factory()->create();
+        $magazzino = Magazzino::factory()->create();
+        $ubicazione = Ubicazione::factory()->create(['magazzino_id' => $magazzino->id]);
+        $articolo = Articolo::factory()->create();
+
+        $component = Livewire::test(ContoLavoroWizard::class)
+            ->set('invio.terzista_id', $terzista->id)
+            ->set('invio.magazzino_id', $magazzino->id)
+            ->set('invio.ubicazione_id', $ubicazione->id)
+            ->set('invio.data_invio', now()->toDateString())
+            ->call('next')
+            ->assertSet('step', 2);
+
+        $component
+            ->set('righe.0.articolo_id', $articolo->id)
+            ->set('righe.0.qta', '5')
+            ->call('next')
+            ->assertSet('step', 3);
+    }
+}

--- a/tests/Unit/MovimentoTest.php
+++ b/tests/Unit/MovimentoTest.php
@@ -1,14 +1,42 @@
-<?php // tests/Unit/MovimentoTest.php
-use App\Models\{Movimento,Articolo,Magazzino};
+<?php
 
-it('imposta correttamente i riferimenti a magazzini origine/destinazione', function(){
-  $a = Articolo::factory()->create();
-  $mo = Magazzino::factory()->create();
-  $md = Magazzino::factory()->create();
+namespace Tests\Unit;
 
-  $out = Movimento::create(['tipo'=>'TRASF','articolo_id'=>$a->id,'qta'=>1,'magazzino_orig'=>$mo->id]);
-  $in  = Movimento::create(['tipo'=>'TRASF','articolo_id'=>$a->id,'qta'=>1,'magazzino_dest'=>$md->id]);
+use App\Models\Articolo;
+use App\Models\Magazzino;
+use App\Models\Movimento;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
-  expect($out->origineMag->id)->toBe($mo->id)
-    ->and($in->destinazioneMag->id)->toBe($md->id);
-});
+class MovimentoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_imposta_correttamente_riferimenti_magazzini(): void
+    {
+        $utente = User::factory()->create();
+        $articolo = Articolo::factory()->create();
+        $magazzinoOrig = Magazzino::factory()->create();
+        $magazzinoDest = Magazzino::factory()->create();
+
+        $out = Movimento::create([
+            'tipo' => 'TRASF',
+            'articolo_id' => $articolo->id,
+            'qta' => 1,
+            'magazzino_orig' => $magazzinoOrig->id,
+            'utente_id' => $utente->id,
+        ]);
+
+        $in = Movimento::create([
+            'tipo' => 'TRASF',
+            'articolo_id' => $articolo->id,
+            'qta' => 1,
+            'magazzino_dest' => $magazzinoDest->id,
+            'utente_id' => $utente->id,
+        ]);
+
+        $this->assertSame($magazzinoOrig->id, $out->origineMag->id);
+        $this->assertSame($magazzinoDest->id, $in->destinazioneMag->id);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap movement wizard navigation in validation/exception guards so users see helpful guidance and unexpected issues are logged
- restyle all wizard layouts with knitwear-inspired hero sections, gradients, and new background illustrations for a richer mobile-friendly experience
- add regression coverage for wizard advancement flows and migrate legacy pest-style tests to PHPUnit classes

## Testing
- php artisan test *(fails: existing suite requires configured app key and database views when running against SQLite)*

------
https://chatgpt.com/codex/tasks/task_e_68db943f02d8832dbc95e0074ea04004