### PR TITLE
Rebuild movement wizards on updated base

### DIFF
--- a/public/images/knit-fibers.svg
+++ b/public/images/knit-fibers.svg
@@ -1,0 +1,18 @@
+<svg width="320" height="220" viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Texture di filati</title>
+  <desc id="desc">Linee intrecciate che richiamano fibre tessili.</desc>
+  <defs>
+    <linearGradient id="fibersGradient" x1="0" y1="0" x2="320" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fde68a"/>
+      <stop offset="0.45" stop-color="#fbcfe8"/>
+      <stop offset="1" stop-color="#c4b5fd"/>
+    </linearGradient>
+    <pattern id="fiberLines" width="24" height="24" patternUnits="userSpaceOnUse" patternTransform="rotate(25)">
+      <path d="M0 12H24" stroke="rgba(255,255,255,0.6)" stroke-width="6" stroke-linecap="round"/>
+    </pattern>
+  </defs>
+  <rect width="320" height="220" rx="36" fill="url(#fibersGradient)"/>
+  <rect x="18" y="18" width="284" height="184" rx="32" fill="url(#fiberLines)" opacity="0.65"/>
+  <path d="M30 40C80 120 130 60 180 140C210 188 250 182 290 150" stroke="rgba(255,255,255,0.75)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M30 120C60 160 110 160 150 110C200 50 250 90 290 70" stroke="rgba(255,255,255,0.45)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/loom-weave.svg
+++ b/public/images/loom-weave.svg
@@ -1,0 +1,26 @@
+<svg width="320" height="220" viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Telaio stilizzato</title>
+  <desc id="desc">Geometrie intrecciate che richiamano l&#39;ordito di un telaio.</desc>
+  <defs>
+    <linearGradient id="warpGradient" x1="0" y1="0" x2="0" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#e0f2fe"/>
+      <stop offset="1" stop-color="#c7d2fe"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="220" rx="36" fill="url(#warpGradient)"/>
+  <g stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M40 30V190" stroke="#38bdf8"/>
+    <path d="M80 30V190" stroke="#818cf8"/>
+    <path d="M120 30V190" stroke="#38bdf8"/>
+    <path d="M160 30V190" stroke="#6366f1"/>
+    <path d="M200 30V190" stroke="#38bdf8"/>
+    <path d="M240 30V190" stroke="#818cf8"/>
+    <path d="M280 30V190" stroke="#38bdf8"/>
+  </g>
+  <g stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.8">
+    <path d="M30 70H290" stroke="#f97316"/>
+    <path d="M30 110H290" stroke="#f59e0b"/>
+    <path d="M30 150H290" stroke="#fb7185"/>
+  </g>
+  <rect x="32" y="32" width="256" height="156" rx="26" stroke="rgba(255,255,255,0.6)" stroke-width="8" fill="none"/>
+</svg>

--- a/public/images/warehouse-racks.svg
+++ b/public/images/warehouse-racks.svg
@@ -1,0 +1,31 @@
+<svg width="320" height="220" viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magazzino stilizzato</title>
+  <desc id="desc">Scaffalature geometriche che richiamano un deposito moderno.</desc>
+  <defs>
+    <linearGradient id="rackGradient" x1="0" y1="0" x2="320" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f1f5f9"/>
+      <stop offset="1" stop-color="#bfdbfe"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="220" rx="36" fill="url(#rackGradient)"/>
+  <g stroke="#1d4ed8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <rect x="50" y="40" width="70" height="140" rx="12" fill="#ffffff"/>
+    <rect x="130" y="40" width="70" height="140" rx="12" fill="#ffffff"/>
+    <rect x="210" y="40" width="60" height="140" rx="12" fill="#ffffff"/>
+    <path d="M50 90H120"/>
+    <path d="M50 140H120"/>
+    <path d="M130 90H200"/>
+    <path d="M130 140H200"/>
+    <path d="M210 90H270"/>
+    <path d="M210 140H270"/>
+  </g>
+  <g fill="#3b82f6" opacity="0.85">
+    <rect x="60" y="60" width="50" height="26" rx="6"/>
+    <rect x="60" y="110" width="50" height="26" rx="6"/>
+    <rect x="140" y="60" width="50" height="26" rx="6"/>
+    <rect x="140" y="110" width="50" height="26" rx="6"/>
+    <rect x="220" y="60" width="40" height="26" rx="6"/>
+    <rect x="220" y="110" width="40" height="26" rx="6"/>
+  </g>
+  <path d="M36 188H284" stroke="rgba(15,23,42,0.35)" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/resources/views/livewire/movimenti/carico-wizard.blade.php
+++ b/resources/views/livewire/movimenti/carico-wizard.blade.php
@@ -1,166 +1,273 @@
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Registrazione carico</h1>
+@php
+    $steps = [
+        1 => ['label' => 'Dati generali', 'subtitle' => 'Magazzino e riferimenti'],
+        2 => ['label' => 'Articoli', 'subtitle' => 'Quantità e lotti'],
+        3 => ['label' => 'Riepilogo', 'subtitle' => 'Controlla e conferma'],
+    ];
+@endphp
 
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Dati generali',2=>'Articoli',3=>'Riepilogo'] as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-green-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
+<div class="wizard-shell min-h-screen bg-gradient-to-br from-rose-50 via-white to-sky-50 pb-10 pt-6">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 lg:px-6">
+        <section class="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-8 shadow-lg backdrop-blur">
+            <div class="absolute -right-12 -top-16 hidden h-56 w-56 rotate-6 rounded-full bg-brand-100 blur-3xl md:block"></div>
+            <img src="{{ asset('images/warehouse-racks.svg') }}" alt="Illustrazione del magazzino" class="absolute -right-6 bottom-0 w-48 opacity-80 md:-right-4 md:w-64 lg:w-72" aria-hidden="true">
+            <div class="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold uppercase tracking-wider text-brand-600">Movimenti • Carico</p>
+                    <h1 class="text-3xl font-semibold text-slate-900">Accetta la merce in ingresso con pochi passaggi</h1>
+                    <p class="max-w-2xl text-sm text-slate-600">Compila i dati principali, aggiungi gli articoli e verifica subito il riepilogo prima di confermare. L&#39;interfaccia è pensata anche per l&#39;uso da smartphone.</p>
+                </div>
+                <dl class="grid grid-cols-2 gap-4 rounded-2xl border border-slate-200/80 bg-white/70 p-4 text-sm text-slate-600 md:w-64">
+                    <div>
+                        <dt class="font-semibold text-slate-500">Passo corrente</dt>
+                        <dd class="text-lg font-semibold text-slate-900">{{ $steps[$step]['label'] }}</dd>
+                    </div>
+                    <div>
+                        <dt class="font-semibold text-slate-500">Stato</dt>
+                        <dd class="flex items-center gap-1 text-brand-600">
+                            <span class="h-2 w-2 rounded-full bg-brand-500"></span>
+                            Attivo
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        </section>
 
-  @if($step === 1)
-    <div class="card space-y-4">
-      <div>
-        <label class="block text-sm font-medium">Magazzino di destinazione</label>
-        <select wire:model="contesto.magazzino_id" class="w-full border rounded-xl p-2">
-          <option value="">— seleziona —</option>
-          @foreach($magazzini as $m)
-            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-          @endforeach
-        </select>
-        @error('contesto.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-      </div>
+        <div class="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur">
+            <ol class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+                @foreach($steps as $index => $info)
+                    <li class="relative flex flex-1 items-start gap-3 sm:flex-col sm:items-center sm:text-center">
+                        <span
+                            class="flex h-11 w-11 items-center justify-center rounded-2xl border text-sm font-semibold transition @if($step > $index) border-brand-600 bg-brand-600 text-white shadow-md @elseif($step === $index) border-brand-600 bg-brand-50 text-brand-700 shadow @else border-slate-200 bg-white text-slate-400 @endif">
+                            {{ $index }}
+                        </span>
+                        <div class="flex-1 sm:flex sm:flex-col sm:items-center">
+                            <p class="text-sm font-semibold text-slate-900">{{ $info['label'] }}</p>
+                            <p class="text-xs text-slate-500">{{ $info['subtitle'] }}</p>
+                        </div>
+                        @if($index < count($steps))
+                            <span class="absolute left-5 top-5 hidden h-px w-full translate-y-1/2 bg-gradient-to-r from-slate-200 via-slate-100 to-slate-200 sm:block"></span>
+                        @endif
+                    </li>
+                @endforeach
+            </ol>
 
-      @if($ubicazioni->isNotEmpty())
-        <div>
-          <label class="block text-sm font-medium">Ubicazione</label>
-          <select wire:model="contesto.ubicazione_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ubicazioni as $u)
-              <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-            @endforeach
-          </select>
-          @error('contesto.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-      @elseif($contesto['magazzino_id'])
-        <p class="text-xs text-slate-500">Il magazzino selezionato non ha ubicazioni attive: il carico sarà registrato a livello magazzino.</p>
-      @endif
+            <div class="mt-8 space-y-6">
+                @if($step === 1)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Dati di carico</h2>
+                            <p class="text-sm text-slate-600">Seleziona il magazzino di destinazione e completa i riferimenti utili alla movimentazione.</p>
+                        </header>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm">Commessa</label>
-          <input type="text" wire:model.lazy="contesto.commessa" class="w-full border rounded-xl p-2" placeholder="Es. PRJ-2025" />
-          @error('contesto.commessa')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Riferimento documento</label>
-          <input type="text" wire:model.lazy="contesto.riferimento" class="w-full border rounded-xl p-2" placeholder="DDT, ordine..." />
-          @error('contesto.riferimento')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Bagno</label>
-          <input type="text" wire:model.lazy="contesto.bagno" class="w-full border rounded-xl p-2" />
-        </div>
-        <div>
-          <label class="block text-sm">Linea</label>
-          <input type="text" wire:model.lazy="contesto.linea" class="w-full border rounded-xl p-2" />
-        </div>
-      </div>
+                        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="magazzino">Magazzino di destinazione</label>
+                                <select id="magazzino" wire:model="contesto.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($magazzini as $m)
+                                        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                    @endforeach
+                                </select>
+                                @error('contesto.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
 
-      <div>
-        <label class="block text-sm">Note operative</label>
-        <textarea wire:model.lazy="contesto.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Indicazioni per il magazzino..."></textarea>
-      </div>
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="ubicazione">Ubicazione</label>
+                                <select id="ubicazione" wire:model="contesto.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($ubicazioni as $u)
+                                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                    @endforeach
+                                </select>
+                                @error('contesto.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                @if($ubicazioni->isEmpty() && $contesto['magazzino_id'])
+                                    <p class="text-xs text-slate-500">Il magazzino selezionato non ha ubicazioni attive: il carico verrà assegnato al magazzino.</p>
+                                @endif
+                            </div>
+
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="commessa">Commessa</label>
+                                <input id="commessa" type="text" wire:model.lazy="contesto.commessa" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500" placeholder="Es. PRJ-2025">
+                                @error('contesto.commessa')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="riferimento">Riferimento documento</label>
+                                <input id="riferimento" type="text" wire:model.lazy="contesto.riferimento" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500" placeholder="DDT, ordine…">
+                                @error('contesto.riferimento')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="bagno">Bagno</label>
+                                <input id="bagno" type="text" wire:model.lazy="contesto.bagno" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                @error('contesto.bagno')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label class="text-sm font-semibold text-slate-700" for="linea">Linea</label>
+                                <input id="linea" type="text" wire:model.lazy="contesto.linea" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                @error('contesto.linea')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+                        </div>
+
+                        <div class="space-y-2">
+                            <label class="text-sm font-semibold text-slate-700" for="note">Note operative</label>
+                            <textarea id="note" rows="3" wire:model.lazy="contesto.note" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500" placeholder="Indicazioni per il magazzino…"></textarea>
+                            @error('contesto.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 2)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <header>
+                                <h2 class="text-lg font-semibold text-slate-900">Articoli in ingresso</h2>
+                                <p class="text-sm text-slate-600">Inserisci ogni riga con articolo, quantità e lotto opzionale.</p>
+                            </header>
+                            <button type="button" wire:click="addRiga" class="btn-secondary rounded-2xl px-4 py-2 text-sm font-semibold text-brand-600 shadow-sm hover:bg-brand-50 hover:text-brand-700">
+                                + Aggiungi riga
+                            </button>
+                        </div>
+
+                        <div class="space-y-6">
+                            @foreach($righe as $i => $riga)
+                                <article wire:key="carico-riga-{{ $i }}" class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <div class="grid grid-cols-1 gap-4 md:grid-cols-12">
+                                        <div class="md:col-span-6 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="articolo-{{ $i }}">Articolo</label>
+                                            <select id="articolo-{{ $i }}" wire:model="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                                <option value="">— seleziona —</option>
+                                                @foreach($articoli as $a)
+                                                    <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                                                @endforeach
+                                            </select>
+                                            @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+
+                                        <div class="md:col-span-3 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="qta-{{ $i }}">Q.tà</label>
+                                            <input id="qta-{{ $i }}" type="number" min="0" step="0.001" wire:model.lazy="righe.{{ $i }}.qta" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                            @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+
+                                        <div class="md:col-span-2 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="lotto-{{ $i }}">Lotto</label>
+                                            <input id="lotto-{{ $i }}" type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                            @error("righe.$i.lotto")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+
+                                        <div class="md:col-span-1 flex items-end">
+                                            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50/70 p-3 text-sm font-semibold text-rose-600 shadow-sm transition hover:bg-rose-100">
+                                                🗑️
+                                            </button>
+                                        </div>
+                                    </div>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 3)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                                <h2 class="text-lg font-semibold text-slate-900">Riepilogo carico</h2>
+                                <p class="text-sm text-slate-600">Controlla le informazioni prima di registrare il movimento.</p>
+                            </div>
+                            <button type="button" wire:click="back" class="btn-ghost text-sm font-semibold text-brand-600 hover:text-brand-700">
+                                ↺ Modifica dati
+                            </button>
+                        </header>
+
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Magazzino</h3>
+                                <p class="text-base font-semibold text-slate-900">{{ $riepilogo['magazzino'] ?? '—' }}</p>
+                                @if($riepilogo['ubicazione'] ?? false)
+                                    <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</p>
+                                @endif
+                            </div>
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Riferimenti</h3>
+                                <dl class="space-y-1 text-sm text-slate-700">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Commessa</dt>
+                                        <dd class="font-medium">{{ $contesto['commessa'] ?: '—' }}</dd>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Documento</dt>
+                                        <dd class="font-medium">{{ $contesto['riferimento'] ?: '—' }}</dd>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Bagno</dt>
+                                        <dd class="font-medium">{{ $contesto['bagno'] ?: '—' }}</dd>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Linea</dt>
+                                        <dd class="font-medium">{{ $contesto['linea'] ?: '—' }}</dd>
+                                    </div>
+                                </dl>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <tr>
+                                        <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                        <th scope="col" class="px-4 py-3 text-right">Q.tà</th>
+                                        <th scope="col" class="px-4 py-3 text-left">Lotto</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white/80">
+                                    @foreach($riepilogo['righe'] ?? [] as $r)
+                                        <tr>
+                                            <td class="px-4 py-3 font-medium text-slate-700">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                                            <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['qta'] }}</td>
+                                            <td class="px-4 py-3 text-slate-600">{{ $r['lotto'] ?: '—' }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+                @endif
+
+                @if ($errors->has('general'))
+                    <div class="rounded-2xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700 shadow-sm">
+                        {{ $errors->first('general') }}
+                    </div>
+                @endif
+            </div>
+
+            <footer class="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button type="button" class="btn-secondary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="back" @disabled($step===1)>
+                    Indietro
+                </button>
+
+                <div class="flex items-center gap-3">
+                    @if($step < 3)
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="next">Avanti</span>
+                            <span wire:loading wire:target="next">Attendere…</span>
+                        </button>
+                    @else
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="conferma">Conferma carico</span>
+                            <span wire:loading wire:target="conferma">Salvataggio…</span>
+                        </button>
+                    @endif
+                </div>
+            </footer>
+
+            @if (session('ok'))
+                <div class="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-700 shadow-sm">
+                    {{ session('ok') }}
+                </div>
+            @endif
+        </div>
     </div>
-  @endif
-
-  @if($step === 2)
-    <div class="card space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="font-medium">Articoli in ingresso</h2>
-        <button type="button" wire:click="addRiga" class="btn-secondary">+ Aggiungi riga</button>
-      </div>
-
-      @foreach($righe as $i => $riga)
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-end">
-          <div class="md:col-span-6">
-            <label class="block text-sm">Articolo</label>
-            <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($articoli as $a)
-                <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
-              @endforeach
-            </select>
-            @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-3">
-            <label class="block text-sm">Q.tà (kg/pz)</label>
-            <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-2">
-            <label class="block text-sm">Lotto</label>
-            <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.lotto")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-1">
-            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-xl p-2 hover:bg-red-50">🗑️</button>
-          </div>
-        </div>
-        <hr class="border-dashed">
-      @endforeach
-    </div>
-  @endif
-
-  @if($step === 3)
-    <div class="card space-y-4">
-      <h2 class="font-medium">Riepilogo carico</h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div>
-          <div class="font-semibold">Magazzino</div>
-          <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-          @if($riepilogo['ubicazione'] ?? false)
-            <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-          @endif
-        </div>
-        <div>
-          <div class="font-semibold">Commessa</div>
-          <div>{{ $contesto['commessa'] ?: '—' }}</div>
-          <div class="text-xs text-slate-500">Rif: {{ $contesto['riferimento'] ?: '—' }}</div>
-        </div>
-      </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="text-left py-2">Articolo</th>
-              <th class="text-right">Q.tà</th>
-              <th class="text-left">Lotto</th>
-            </tr>
-          </thead>
-          <tbody>
-            @foreach($riepilogo['righe'] ?? [] as $r)
-              <tr class="border-b">
-                <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                <td class="text-right">{{ $r['qta'] }}</td>
-                <td>{{ $r['lotto'] ?: '—' }}</td>
-              </tr>
-            @endforeach
-          </tbody>
-        </table>
-      </div>
-    </div>
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma carico</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
-  </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/resources/views/livewire/movimenti/conto-lavoro-wizard.blade.php
+++ b/resources/views/livewire/movimenti/conto-lavoro-wizard.blade.php
@@ -1,303 +1,408 @@
-<div class="mx-auto max-w-6xl p-4 space-y-6">
-  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-    <h1 class="text-2xl font-semibold">Gestione conto lavoro</h1>
-    <div class="flex rounded-xl border border-slate-200 dark:border-slate-700 overflow-hidden">
-      <button type="button" wire:click="switchFase('invio')" class="px-4 py-2 text-sm font-medium {{ $fase === 'invio' ? 'bg-brand-600 text-white' : 'bg-white dark:bg-slate-900' }}">Invio ai terzisti</button>
-      <button type="button" wire:click="switchFase('rientro')" class="px-4 py-2 text-sm font-medium {{ $fase === 'rientro' ? 'bg-brand-600 text-white' : 'bg-white dark:bg-slate-900' }}">Rientro lavorazioni</button>
-    </div>
-  </div>
+@php
+    $stepLabels = $fase === 'invio'
+        ? [1 => ['label' => 'Dati invio', 'subtitle' => 'Terzista e magazzino'], 2 => ['label' => 'Articoli', 'subtitle' => 'Quantità e componenti'], 3 => ['label' => 'Riepilogo', 'subtitle' => 'Controlla e conferma']]
+        : [1 => ['label' => 'Ordine', 'subtitle' => 'Seleziona rientro'], 2 => ['label' => 'Quantità', 'subtitle' => 'Rientri e scarti'], 3 => ['label' => 'Riepilogo', 'subtitle' => 'Verifica finale']];
+@endphp
 
-  <div class="flex items-center gap-2 text-sm">
-    @php($labels = $fase === 'invio' ? [1=>'Dati invio',2=>'Articoli',3=>'Riepilogo'] : [1=>'Ordine e magazzino',2=>'Quantità rientro',3=>'Riepilogo'])
-    @foreach ($labels as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-violet-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
+<div class="wizard-shell min-h-screen bg-gradient-to-br from-violet-50 via-white to-emerald-50 pb-10 pt-6">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 lg:px-6">
+        <section class="relative overflow-hidden rounded-3xl border border-white/60 bg-white/85 p-8 shadow-lg backdrop-blur">
+            <div class="absolute -left-16 top-0 h-56 w-56 -rotate-12 rounded-full bg-violet-100 blur-3xl"></div>
+            <img src="{{ asset('images/loom-weave.svg') }}" alt="Illustrazione conto lavoro" class="absolute -right-10 bottom-0 w-56 opacity-80 md:w-72" aria-hidden="true">
+            <div class="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+                <div class="space-y-3">
+                    <p class="text-sm font-semibold uppercase tracking-wider text-violet-600">Gestione conto lavoro</p>
+                    <h1 class="text-3xl font-semibold text-slate-900">Monitora invii ai terzisti e rientri lavorati con un solo flusso</h1>
+                    <p class="max-w-2xl text-sm text-slate-600">Passa rapidamente dall&#39;invio di materiale ai partner esterni al rientro delle lavorazioni. Il percorso guidato ti accompagna su desktop e smartphone.</p>
+                    <div class="inline-flex rounded-2xl border border-slate-200/80 bg-white/80 p-1 shadow-sm">
+                        <button type="button" wire:click="switchFase('invio')" class="rounded-2xl px-4 py-2 text-sm font-semibold transition @if($fase==='invio') bg-violet-600 text-white shadow @else text-slate-600 hover:text-slate-900 @endif">
+                            Invio ai terzisti
+                        </button>
+                        <button type="button" wire:click="switchFase('rientro')" class="rounded-2xl px-4 py-2 text-sm font-semibold transition @if($fase==='rientro') bg-violet-600 text-white shadow @else text-slate-600 hover:text-slate-900 @endif">
+                            Rientro lavorazioni
+                        </button>
+                    </div>
+                </div>
+                <div class="grid gap-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-sm text-slate-600 shadow-sm lg:w-80">
+                    <div>
+                        <p class="font-semibold text-slate-500">Modalità attiva</p>
+                        <p class="text-lg font-semibold text-slate-900">{{ $fase === 'invio' ? 'Invio al terzista' : 'Rientro da terzista' }}</p>
+                    </div>
+                    <p class="text-xs uppercase tracking-wide text-violet-600">Step {{ $step }} di {{ count($stepLabels) }}</p>
+                    @if($fase === 'invio')
+                        <p class="text-xs text-slate-500">Ultimo terzista selezionato: {{ optional($terzisti->firstWhere('id', $invio['terzista_id']))?->ragione_sociale ?? '—' }}</p>
+                    @else
+                        <p class="text-xs text-slate-500">Ordine selezionato: {{ $rientro['ordine_id'] ? '#'.$rientro['ordine_id'] : '—' }}</p>
+                    @endif
+                </div>
+            </div>
+        </section>
 
-  @if($fase === 'invio')
-    @if($step === 1)
-      <div class="card space-y-4">
-        <div>
-          <label class="block text-sm font-medium">Terzista</label>
-          <select wire:model="invio.terzista_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($terzisti as $t)
-              <option value="{{ $t->id }}">{{ $t->ragione_sociale }}</option>
-            @endforeach
-          </select>
-          @error('invio.terzista_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Magazzino di uscita</label>
-            <select wire:model="invio.magazzino_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($magazzini as $m)
-                <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-              @endforeach
-            </select>
-            @error('invio.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Ubicazione</label>
-            <select wire:model="invio.ubicazione_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($ubicazioniInvio as $u)
-                <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-              @endforeach
-            </select>
-            @error('invio.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm">Data invio</label>
-            <input type="date" wire:model="invio.data_invio" class="w-full border rounded-xl p-2" />
-            @error('invio.data_invio')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm">Data rientro prevista</label>
-            <input type="date" wire:model="invio.data_rientro_prevista" class="w-full border rounded-xl p-2" />
-            @error('invio.data_rientro_prevista')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-        </div>
-        <div>
-          <label class="block text-sm">Note per il terzista</label>
-          <textarea wire:model.lazy="invio.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Indicazioni, componenti, urgenze..."></textarea>
-        </div>
-      </div>
-    @endif
-
-    @if($step === 2)
-      <div class="card space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="font-medium">Articoli da inviare</h2>
-          <button type="button" class="btn-secondary" wire:click="addRiga">+ Aggiungi riga</button>
-        </div>
-        @foreach($righe as $i => $riga)
-          <div class="grid grid-cols-1 lg:grid-cols-12 gap-3 items-end">
-            <div class="lg:col-span-5">
-              <label class="block text-sm">Articolo</label>
-              <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-                <option value="">— seleziona —</option>
-                @foreach($articoli as $a)
-                  <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+        <div class="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur">
+            <ol class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+                @foreach($stepLabels as $index => $info)
+                    <li class="relative flex flex-1 items-start gap-3 sm:flex-col sm:items-center sm:text-center">
+                        <span class="flex h-11 w-11 items-center justify-center rounded-2xl border text-sm font-semibold transition @if($step > $index) border-violet-600 bg-violet-600 text-white shadow-md @elseif($step === $index) border-violet-600 bg-violet-50 text-violet-700 shadow @else border-slate-200 bg-white text-slate-400 @endif">
+                            {{ $index }}
+                        </span>
+                        <div class="flex-1 sm:flex sm:flex-col sm:items-center">
+                            <p class="text-sm font-semibold text-slate-900">{{ $info['label'] }}</p>
+                            <p class="text-xs text-slate-500">{{ $info['subtitle'] }}</p>
+                        </div>
+                        @if($index < count($stepLabels))
+                            <span class="absolute left-5 top-5 hidden h-px w-full translate-y-1/2 bg-gradient-to-r from-slate-200 via-slate-100 to-slate-200 sm:block"></span>
+                        @endif
+                    </li>
                 @endforeach
-              </select>
-              @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-            </div>
-            <div class="lg:col-span-2">
-              <label class="block text-sm">Q.tà</label>
-              <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-              @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-            </div>
-            <div class="lg:col-span-2">
-              <label class="block text-sm">Lotto</label>
-              <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-            </div>
-            <div class="lg:col-span-3">
-              <label class="block text-sm">Componenti / lavorazioni</label>
-              <input type="text" wire:model.lazy="righe.{{ $i }}.componenti" class="w-full border rounded-xl p-2" placeholder="Es. fodera, bottoni..." />
-            </div>
-          </div>
-          <hr class="border-dashed">
-        @endforeach
-      </div>
-    @endif
+            </ol>
 
-    @if($step === 3)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Riepilogo invio</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-          <div>
-            <div class="font-semibold">Terzista</div>
-            <div>{{ $riepilogo['terzista'] ?? '—' }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Magazzino</div>
-            <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-            @if($riepilogo['ubicazione'] ?? false)
-              <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-            @endif
-          </div>
-          <div>
-            <div class="font-semibold">Data invio</div>
-            <div>{{ $invio['data_invio'] }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Rientro previsto</div>
-            <div>{{ $invio['data_rientro_prevista'] ?: '—' }}</div>
-          </div>
-        </div>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Articolo</th>
-                <th class="text-right">Q.tà</th>
-                <th class="text-left">Lotto</th>
-                <th class="text-left">Componenti</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($riepilogo['righe'] ?? [] as $r)
-                <tr class="border-b">
-                  <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                  <td class="text-right">{{ $r['qta'] }}</td>
-                  <td>{{ $r['lotto'] ?: '—' }}</td>
-                  <td>{{ $r['componenti'] ?: '—' }}</td>
-                </tr>
-              @endforeach
-            </tbody>
-          </table>
-        </div>
-      </div>
-    @endif
-  @else
-    @if($step === 1)
-      <div class="card space-y-4">
-        <div>
-          <label class="block text-sm font-medium">Ordine conto lavoro</label>
-          <select wire:model="rientro.ordine_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ordiniAperti as $ordine)
-              <option value="{{ $ordine->id }}">#{{ $ordine->id }} — {{ $ordine->terzista?->ragione_sociale }} ({{ $ordine->stato }})</option>
-            @endforeach
-          </select>
-          @error('rientro.ordine_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Magazzino di rientro</label>
-            <select wire:model="rientro.magazzino_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($magazzini as $m)
-                <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-              @endforeach
-            </select>
-            @error('rientro.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Ubicazione</label>
-            <select wire:model="rientro.ubicazione_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($ubicazioniRientro as $u)
-                <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-              @endforeach
-            </select>
-            @error('rientro.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-        </div>
-        <div>
-          <label class="block text-sm">Note interne</label>
-          <textarea wire:model.lazy="rientro.note" rows="3" class="w-full border rounded-xl p-2"></textarea>
-        </div>
-      </div>
-    @endif
+            <div class="mt-8 space-y-6">
+                @if($fase === 'invio')
+                    @if($step === 1)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <header class="space-y-1">
+                                <h2 class="text-lg font-semibold text-slate-900">Dati per l&#39;invio</h2>
+                                <p class="text-sm text-slate-600">Seleziona il terzista e indica da quale magazzino parte la lavorazione.</p>
+                            </header>
 
-    @if($step === 2)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Quantità da rientrare</h2>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Riga</th>
-                <th class="text-right">Inviato</th>
-                <th class="text-right">Disponibile</th>
-                <th class="text-right">Rientro</th>
-                <th class="text-right">Scarto</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($rientroRighe as $i => $riga)
-                <tr class="border-b">
-                  <td class="py-2">
-                    <div>{{ $riga['articolo'] }}</div>
-                    @if($riga['lotto'])<div class="text-xs text-slate-500">Lotto: {{ $riga['lotto'] }}</div>@endif
-                  </td>
-                  <td class="text-right">{{ $riga['qta_inviata'] }}</td>
-                  <td class="text-right">{{ $riga['disponibile'] }}</td>
-                  <td class="text-right">
-                    <input type="number" step="0.001" min="0" max="{{ $riga['disponibile'] }}" wire:model.lazy="rientroRighe.{{ $i }}.qta_rientro" class="w-full border rounded-xl p-1.5" />
-                    @error("rientroRighe.$i.qta_rientro")<p class="text-xs text-red-600">{{ $message }}</p>@enderror
-                  </td>
-                  <td class="text-right">
-                    <input type="number" step="0.001" min="0" wire:model.lazy="rientroRighe.{{ $i }}.scarto" class="w-full border rounded-xl p-1.5" />
-                    @error("rientroRighe.$i.scarto")<p class="text-xs text-red-600">{{ $message }}</p>@enderror
-                  </td>
-                </tr>
-              @endforeach
-            </tbody>
-          </table>
-        </div>
-      </div>
-    @endif
+                            <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                                <div class="space-y-2">
+                                    <label for="terzista" class="text-sm font-semibold text-slate-700">Terzista</label>
+                                    <select id="terzista" wire:model="invio.terzista_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($terzisti as $t)
+                                            <option value="{{ $t->id }}">{{ $t->ragione_sociale }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('invio.terzista_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
 
-    @if($step === 3)
-      <div class="card space-y-4">
-        <h2 class="font-medium">Riepilogo rientro</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-          <div>
-            <div class="font-semibold">Ordine</div>
-            <div>#{{ $riepilogo['ordine'] ?? '—' }}</div>
-          </div>
-          <div>
-            <div class="font-semibold">Magazzino</div>
-            <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-            @if($riepilogo['ubicazione'] ?? false)
-              <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-            @endif
-          </div>
-          <div>
-            <div class="font-semibold">Terzista</div>
-            <div>{{ $riepilogo['terzista'] ?? '—' }}</div>
-          </div>
-        </div>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-sm">
-            <thead>
-              <tr class="border-b">
-                <th class="text-left py-2">Articolo</th>
-                <th class="text-right">Rientro</th>
-                <th class="text-right">Scarto</th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($rientroRighe as $r)
-                @if((float)($r['qta_rientro'] ?? 0) > 0 || (float)($r['scarto'] ?? 0) > 0)
-                  <tr class="border-b">
-                    <td class="py-2">{{ $r['articolo'] }}</td>
-                    <td class="text-right">{{ $r['qta_rientro'] }}</td>
-                    <td class="text-right">{{ $r['scarto'] }}</td>
-                  </tr>
+                                <div class="space-y-2">
+                                    <label for="magazzino-invio" class="text-sm font-semibold text-slate-700">Magazzino di uscita</label>
+                                    <select id="magazzino-invio" wire:model="invio.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($magazzini as $m)
+                                            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                        @endforeach
+                                    </select>
+                                    @error('invio.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+
+                                <div class="space-y-2">
+                                    <label for="ubicazione-invio" class="text-sm font-semibold text-slate-700">Ubicazione</label>
+                                    <select id="ubicazione-invio" wire:model="invio.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($ubicazioniInvio as $u)
+                                            <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('invio.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+
+                                <div class="space-y-2">
+                                    <label for="data-invio" class="text-sm font-semibold text-slate-700">Data invio</label>
+                                    <input id="data-invio" type="date" wire:model="invio.data_invio" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                    @error('invio.data_invio')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+
+                                <div class="space-y-2">
+                                    <label for="data-rientro" class="text-sm font-semibold text-slate-700">Data rientro prevista</label>
+                                    <input id="data-rientro" type="date" wire:model="invio.data_rientro_prevista" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                    @error('invio.data_rientro_prevista')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="note-invio" class="text-sm font-semibold text-slate-700">Note per il terzista</label>
+                                <textarea id="note-invio" rows="3" wire:model.lazy="invio.note" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500" placeholder="Componenti, urgenze, istruzioni…"></textarea>
+                                @error('invio.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+                        </section>
+                    @endif
+
+                    @if($step === 2)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <header>
+                                    <h2 class="text-lg font-semibold text-slate-900">Articoli da inviare</h2>
+                                    <p class="text-sm text-slate-600">Aggiungi ogni riga con quantità, lotto e componenti opzionali.</p>
+                                </header>
+                                <button type="button" class="btn-secondary rounded-2xl px-4 py-2 text-sm font-semibold text-violet-600 shadow-sm hover:bg-violet-50 hover:text-violet-700" wire:click="addRiga">
+                                    + Aggiungi riga
+                                </button>
+                            </div>
+
+                            <div class="space-y-6">
+                                @foreach($righe as $i => $riga)
+                                    <article wire:key="invio-riga-{{ $i }}" class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                        <div class="grid grid-cols-1 gap-4 lg:grid-cols-12">
+                                            <div class="lg:col-span-5 space-y-2">
+                                                <label class="text-sm font-semibold text-slate-700" for="articolo-invio-{{ $i }}">Articolo</label>
+                                                <select id="articolo-invio-{{ $i }}" wire:model="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                                    <option value="">— seleziona —</option>
+                                                    @foreach($articoli as $a)
+                                                        <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                                                    @endforeach
+                                                </select>
+                                                @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                            </div>
+                                            <div class="lg:col-span-2 space-y-2">
+                                                <label class="text-sm font-semibold text-slate-700" for="qta-invio-{{ $i }}">Q.tà</label>
+                                                <input id="qta-invio-{{ $i }}" type="number" min="0" step="0.001" wire:model.lazy="righe.{{ $i }}.qta" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                                @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                            </div>
+                                            <div class="lg:col-span-2 space-y-2">
+                                                <label class="text-sm font-semibold text-slate-700" for="lotto-invio-{{ $i }}">Lotto</label>
+                                                <input id="lotto-invio-{{ $i }}" type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                            </div>
+                                            <div class="lg:col-span-3 space-y-2">
+                                                <label class="text-sm font-semibold text-slate-700" for="componenti-invio-{{ $i }}">Componenti / lavorazioni</label>
+                                                <input id="componenti-invio-{{ $i }}" type="text" wire:model.lazy="righe.{{ $i }}.componenti" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500" placeholder="Es. fodera, bottoni…">
+                                                @error("righe.$i.componenti")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                            </div>
+                                        </div>
+                                    </article>
+                                @endforeach
+                            </div>
+                        </section>
+                    @endif
+
+                    @if($step === 3)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <header class="space-y-1">
+                                <h2 class="text-lg font-semibold text-slate-900">Riepilogo invio</h2>
+                                <p class="text-sm text-slate-600">Conferma i dati prima di registrare l&#39;uscita verso il terzista.</p>
+                            </header>
+
+                            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                                <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Terzista</h3>
+                                    <p class="text-base font-semibold text-slate-900">{{ $riepilogo['terzista'] ?? '—' }}</p>
+                                    <p class="text-sm text-slate-600">Magazzino: <span class="font-semibold text-slate-900">{{ $riepilogo['magazzino'] ?? '—' }}</span></p>
+                                    @if($riepilogo['ubicazione'] ?? false)
+                                        <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</p>
+                                    @endif
+                                </div>
+                                <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Programmazione</h3>
+                                    <dl class="space-y-2 text-sm text-slate-700">
+                                        <div class="flex items-center justify-between gap-4">
+                                            <dt class="text-slate-500">Data invio</dt>
+                                            <dd class="font-medium">{{ $invio['data_invio'] }}</dd>
+                                        </div>
+                                        <div class="flex items-center justify-between gap-4">
+                                            <dt class="text-slate-500">Rientro previsto</dt>
+                                            <dd class="font-medium">{{ $invio['data_rientro_prevista'] ?: '—' }}</dd>
+                                        </div>
+                                        <div class="flex items-center justify-between gap-4">
+                                            <dt class="text-slate-500">Note</dt>
+                                            <dd class="font-medium text-right">{{ $invio['note'] ?: '—' }}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+
+                            <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                    <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Q.tà</th>
+                                            <th scope="col" class="px-4 py-3 text-left">Lotto</th>
+                                            <th scope="col" class="px-4 py-3 text-left">Componenti</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-slate-100 bg-white/80">
+                                        @foreach($riepilogo['righe'] ?? [] as $r)
+                                            <tr>
+                                                <td class="px-4 py-3 font-medium text-slate-700">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                                                <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['qta'] }}</td>
+                                                <td class="px-4 py-3 text-slate-600">{{ $r['lotto'] ?: '—' }}</td>
+                                                <td class="px-4 py-3 text-slate-600">{{ $r['componenti'] ?: '—' }}</td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    @endif
+                @else
+                    @if($step === 1)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <header class="space-y-1">
+                                <h2 class="text-lg font-semibold text-slate-900">Seleziona l&#39;ordine in rientro</h2>
+                                <p class="text-sm text-slate-600">Scegli il documento di conto lavoro e il magazzino in cui registrare i pezzi rientrati.</p>
+                            </header>
+
+                            <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                                <div class="space-y-2">
+                                    <label for="ordine-rientro" class="text-sm font-semibold text-slate-700">Ordine conto lavoro</label>
+                                    <select id="ordine-rientro" wire:model="rientro.ordine_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($ordiniAperti as $ordine)
+                                            <option value="{{ $ordine->id }}">#{{ $ordine->id }} — {{ $ordine->terzista?->ragione_sociale }} ({{ $ordine->stato }})</option>
+                                        @endforeach
+                                    </select>
+                                    @error('rientro.ordine_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+
+                                <div class="space-y-2">
+                                    <label for="magazzino-rientro" class="text-sm font-semibold text-slate-700">Magazzino di rientro</label>
+                                    <select id="magazzino-rientro" wire:model="rientro.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($magazzini as $m)
+                                            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                        @endforeach
+                                    </select>
+                                    @error('rientro.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+
+                                <div class="space-y-2">
+                                    <label for="ubicazione-rientro" class="text-sm font-semibold text-slate-700">Ubicazione</label>
+                                    <select id="ubicazione-rientro" wire:model="rientro.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                        <option value="">— seleziona —</option>
+                                        @foreach($ubicazioniRientro as $u)
+                                            <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('rientro.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                </div>
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="note-rientro" class="text-sm font-semibold text-slate-700">Note interne</label>
+                                <textarea id="note-rientro" rows="3" wire:model.lazy="rientro.note" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500" placeholder="Annotazioni sul rientro, difetti, ecc."></textarea>
+                                @error('rientro.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+                        </section>
+                    @endif
+
+                    @if($step === 2)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <header class="space-y-1">
+                                <h2 class="text-lg font-semibold text-slate-900">Quantità da rientrare</h2>
+                                <p class="text-sm text-slate-600">Inserisci le quantità rientrate e gli eventuali scarti per ogni riga.</p>
+                            </header>
+
+                            <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                    <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Inviato</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Disponibile</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Rientro</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Scarto</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-slate-100 bg-white/80">
+                                        @foreach($rientroRighe as $i => $riga)
+                                            <tr>
+                                                <td class="px-4 py-3">
+                                                    <div class="font-medium text-slate-700">{{ $riga['articolo'] }}</div>
+                                                    @if($riga['lotto'])
+                                                        <div class="text-xs text-slate-500">Lotto: {{ $riga['lotto'] }}</div>
+                                                    @endif
+                                                </td>
+                                                <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $riga['qta_inviata'] }}</td>
+                                                <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $riga['disponibile'] }}</td>
+                                                <td class="px-4 py-3 text-right">
+                                                    <input type="number" min="0" max="{{ $riga['disponibile'] }}" step="0.001" wire:model.lazy="rientroRighe.{{ $i }}.qta_rientro" class="w-28 rounded-2xl border-slate-200 bg-white/90 p-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                                    @error("rientroRighe.$i.qta_rientro")<p class="text-xs text-rose-600">{{ $message }}</p>@enderror
+                                                </td>
+                                                <td class="px-4 py-3 text-right">
+                                                    <input type="number" min="0" step="0.001" wire:model.lazy="rientroRighe.{{ $i }}.scarto" class="w-24 rounded-2xl border-slate-200 bg-white/90 p-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500">
+                                                    @error("rientroRighe.$i.scarto")<p class="text-xs text-rose-600">{{ $message }}</p>@enderror
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    @endif
+
+                    @if($step === 3)
+                        <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                            <header class="space-y-1">
+                                <h2 class="text-lg font-semibold text-slate-900">Riepilogo rientro</h2>
+                                <p class="text-sm text-slate-600">Rivedi l&#39;ordine e le quantità che stai registrando.</p>
+                            </header>
+
+                            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                                <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Ordine</h3>
+                                    <p class="text-base font-semibold text-slate-900">#{{ $riepilogo['ordine'] ?? '—' }}</p>
+                                    <p class="text-sm text-slate-600">Terzista: <span class="font-semibold text-slate-900">{{ $riepilogo['terzista'] ?? '—' }}</span></p>
+                                </div>
+                                <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Magazzino</h3>
+                                    <p class="text-base font-semibold text-slate-900">{{ $riepilogo['magazzino'] ?? '—' }}</p>
+                                    @if($riepilogo['ubicazione'] ?? false)
+                                        <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</p>
+                                    @endif
+                                    <p class="mt-2 text-sm text-slate-600">Note: <span class="font-semibold text-slate-900">{{ $rientro['note'] ?: '—' }}</span></p>
+                                </div>
+                            </div>
+
+                            <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                    <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Rientro</th>
+                                            <th scope="col" class="px-4 py-3 text-right">Scarto</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-slate-100 bg-white/80">
+                                        @foreach($rientroRighe as $r)
+                                            @if((float)($r['qta_rientro'] ?? 0) > 0 || (float)($r['scarto'] ?? 0) > 0)
+                                                <tr>
+                                                    <td class="px-4 py-3 font-medium text-slate-700">{{ $r['articolo'] }}</td>
+                                                    <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['qta_rientro'] }}</td>
+                                                    <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['scarto'] }}</td>
+                                                </tr>
+                                            @endif
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    @endif
                 @endif
-              @endforeach
-            </tbody>
-          </table>
+
+                @if ($errors->has('general'))
+                    <div class="rounded-2xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700 shadow-sm">
+                        {{ $errors->first('general') }}
+                    </div>
+                @endif
+            </div>
+
+            <footer class="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button type="button" class="btn-secondary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="back" @disabled($step===1)>
+                    Indietro
+                </button>
+
+                <div class="flex items-center gap-3">
+                    @if($step < 3)
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="next">Avanti</span>
+                            <span wire:loading wire:target="next">Attendere…</span>
+                        </button>
+                    @else
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="conferma">Conferma</span>
+                            <span wire:loading wire:target="conferma">Salvataggio…</span>
+                        </button>
+                    @endif
+                </div>
+            </footer>
+
+            @if (session('ok'))
+                <div class="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-700 shadow-sm">
+                    {{ session('ok') }}
+                </div>
+            @endif
         </div>
-      </div>
-    @endif
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
-  </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
+    </div>
 </div>

--- a/resources/views/livewire/movimenti/scarico-wizard.blade.php
+++ b/resources/views/livewire/movimenti/scarico-wizard.blade.php
@@ -1,182 +1,263 @@
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Prelievo / Reso magazzino</h1>
+@php
+    $steps = [
+        1 => ['label' => 'Contesto', 'subtitle' => 'Operazione e riferimenti'],
+        2 => ['label' => 'Articoli', 'subtitle' => 'Dettaglio prelievo/reso'],
+        3 => ['label' => 'Riepilogo', 'subtitle' => 'Verifica finale'],
+    ];
+@endphp
 
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Contesto',2=>'Articoli',3=>'Riepilogo'] as $i => $label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-amber-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i < 3)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
+<div class="wizard-shell min-h-screen bg-gradient-to-br from-amber-50 via-white to-slate-100 pb-10 pt-6">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 lg:px-6">
+        <section class="relative overflow-hidden rounded-3xl border border-white/60 bg-white/85 p-8 shadow-lg backdrop-blur">
+            <div class="absolute -left-10 top-0 h-52 w-52 -translate-y-8 rotate-12 rounded-full bg-amber-100 blur-3xl"></div>
+            <img src="{{ asset('images/knit-fibers.svg') }}" alt="Illustrazione filati" class="absolute -right-10 bottom-0 w-52 opacity-80 md:w-64 lg:w-72" aria-hidden="true">
+            <div class="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold uppercase tracking-wider text-amber-600">Movimenti • Prelievo / Reso</p>
+                    <h1 class="text-3xl font-semibold text-slate-900">Coordina uscite e rientri di magazzino in modo chiaro</h1>
+                    <p class="max-w-2xl text-sm text-slate-600">Scegli l&#39;operazione, indica le quantità e registra eventuali resi in pochi tap. Tutto ottimizzato per lavorare da tablet o smartphone.</p>
+                </div>
+                <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-sm text-slate-600 shadow-sm md:w-72">
+                    <p class="font-semibold text-slate-500">Operatore attivo</p>
+                    <p class="text-lg font-semibold text-slate-900">{{ $contesto['operatore'] }}</p>
+                    <p class="mt-2 text-xs uppercase tracking-wide text-amber-600">Step {{ $step }} di {{ count($steps) }}</p>
+                </div>
+            </div>
+        </section>
 
-  @if($step === 1)
-    <div class="card space-y-4">
-      <div class="flex items-center gap-3">
-        <label class="text-sm font-medium">Operazione</label>
-        <div class="flex items-center gap-2">
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input type="radio" wire:model="contesto.tipo" value="prelievo" class="accent-brand-600">
-            <span>Prelievo</span>
-          </label>
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input type="radio" wire:model="contesto.tipo" value="reso" class="accent-brand-600">
-            <span>Reso</span>
-          </label>
+        <div class="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur">
+            <ol class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+                @foreach($steps as $index => $info)
+                    <li class="relative flex flex-1 items-start gap-3 sm:flex-col sm:items-center sm:text-center">
+                        <span class="flex h-11 w-11 items-center justify-center rounded-2xl border text-sm font-semibold transition @if($step > $index) border-amber-600 bg-amber-500 text-white shadow-md @elseif($step === $index) border-amber-500 bg-amber-50 text-amber-700 shadow @else border-slate-200 bg-white text-slate-400 @endif">
+                            {{ $index }}
+                        </span>
+                        <div class="flex-1 sm:flex sm:flex-col sm:items-center">
+                            <p class="text-sm font-semibold text-slate-900">{{ $info['label'] }}</p>
+                            <p class="text-xs text-slate-500">{{ $info['subtitle'] }}</p>
+                        </div>
+                        @if($index < count($steps))
+                            <span class="absolute left-5 top-5 hidden h-px w-full translate-y-1/2 bg-gradient-to-r from-slate-200 via-slate-100 to-slate-200 sm:block"></span>
+                        @endif
+                    </li>
+                @endforeach
+            </ol>
+
+            <div class="mt-8 space-y-6">
+                @if($step === 1)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Imposta il contesto</h2>
+                            <p class="text-sm text-slate-600">Definisci se si tratta di un prelievo o di un reso e indica magazzino e riferimenti utili.</p>
+                        </header>
+
+                        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                            <span class="text-sm font-semibold text-slate-700">Operazione</span>
+                            <div class="flex gap-3">
+                                <label class="flex items-center gap-2 rounded-2xl border @if($contesto['tipo']==='prelievo') border-amber-500 bg-amber-50 text-amber-700 shadow-sm @else border-slate-200 bg-white text-slate-600 @endif px-4 py-2 text-sm font-semibold transition">
+                                    <input type="radio" wire:model="contesto.tipo" value="prelievo" class="hidden">
+                                    <span>Prelievo</span>
+                                </label>
+                                <label class="flex items-center gap-2 rounded-2xl border @if($contesto['tipo']==='reso') border-amber-500 bg-amber-50 text-amber-700 shadow-sm @else border-slate-200 bg-white text-slate-600 @endif px-4 py-2 text-sm font-semibold transition">
+                                    <input type="radio" wire:model="contesto.tipo" value="reso" class="hidden">
+                                    <span>Reso</span>
+                                </label>
+                            </div>
+                        </div>
+                        @error('contesto.tipo')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+
+                        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                            <div class="space-y-2">
+                                <label for="magazzino" class="text-sm font-semibold text-slate-700">Magazzino</label>
+                                <select id="magazzino" wire:model="contesto.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($magazzini as $m)
+                                        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                    @endforeach
+                                </select>
+                                @error('contesto.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="ubicazione" class="text-sm font-semibold text-slate-700">Ubicazione</label>
+                                <select id="ubicazione" wire:model="contesto.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($ubicazioni as $u)
+                                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                    @endforeach
+                                </select>
+                                @error('contesto.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                @if($ubicazioni->isEmpty() && $contesto['magazzino_id'])
+                                    <p class="text-xs text-slate-500">Non ci sono ubicazioni attive per il magazzino selezionato.</p>
+                                @endif
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="operatore" class="text-sm font-semibold text-slate-700">Operatore</label>
+                                <input id="operatore" type="text" wire:model.lazy="contesto.operatore" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                @error('contesto.operatore')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="commessa" class="text-sm font-semibold text-slate-700">Commessa</label>
+                                <input id="commessa" type="text" wire:model.lazy="contesto.commessa" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                @error('contesto.commessa')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2 lg:col-span-2">
+                                <label for="destinatario" class="text-sm font-semibold text-slate-700">Destinatario / Reparto</label>
+                                <input id="destinatario" type="text" wire:model.lazy="contesto.destinatario" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500" placeholder="Es. sartoria, terzista…">
+                                @error('contesto.destinatario')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+                        </div>
+
+                        <div class="space-y-2">
+                            <label for="note" class="text-sm font-semibold text-slate-700">Note</label>
+                            <textarea id="note" rows="3" wire:model.lazy="contesto.note" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500" placeholder="Dettagli aggiuntivi"></textarea>
+                            @error('contesto.note')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 2)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <header>
+                                <h2 class="text-lg font-semibold text-slate-900">Articoli movimentati</h2>
+                                <p class="text-sm text-slate-600">Specifica gli articoli interessati, la quantità e l&#39;eventuale lotto.</p>
+                            </header>
+                            <button type="button" wire:click="addRiga" class="btn-secondary rounded-2xl px-4 py-2 text-sm font-semibold text-amber-600 shadow-sm hover:bg-amber-50 hover:text-amber-700">
+                                + Aggiungi riga
+                            </button>
+                        </div>
+
+                        <div class="space-y-6">
+                            @foreach($righe as $i => $riga)
+                                <article wire:key="scarico-riga-{{ $i }}" class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <div class="grid grid-cols-1 gap-4 md:grid-cols-12">
+                                        <div class="md:col-span-6 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="articolo-{{ $i }}">Articolo</label>
+                                            <select id="articolo-{{ $i }}" wire:model="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                                <option value="">— seleziona —</option>
+                                                @foreach($articoli as $a)
+                                                    <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                                                @endforeach
+                                            </select>
+                                            @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+                                        <div class="md:col-span-3 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="qta-{{ $i }}">Q.tà</label>
+                                            <input id="qta-{{ $i }}" type="number" min="0" step="0.001" wire:model.lazy="righe.{{ $i }}.qta" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                            @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+                                        <div class="md:col-span-2 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="lotto-{{ $i }}">Lotto</label>
+                                            <input id="lotto-{{ $i }}" type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500">
+                                        </div>
+                                        <div class="md:col-span-1 flex items-end">
+                                            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50/80 p-3 text-sm font-semibold text-rose-600 shadow-sm transition hover:bg-rose-100">
+                                                🗑️
+                                            </button>
+                                        </div>
+                                    </div>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 3)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Riepilogo operazione</h2>
+                            <p class="text-sm text-slate-600">Verifica tutti i dati prima di confermare l&#39;uscita o il rientro.</p>
+                        </header>
+
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Operazione</h3>
+                                <p class="mt-1 inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                                    {{ strtoupper($contesto['tipo']) }}
+                                </p>
+                                <p class="mt-3 text-sm text-slate-600">Magazzino: <span class="font-semibold text-slate-900">{{ $riepilogo['magazzino'] ?? '—' }}</span></p>
+                                @if($riepilogo['ubicazione'] ?? false)
+                                    <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</p>
+                                @endif
+                            </div>
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Dettagli</h3>
+                                <dl class="space-y-2 text-sm text-slate-700">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Operatore</dt>
+                                        <dd class="font-medium">{{ $contesto['operatore'] }}</dd>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Commessa</dt>
+                                        <dd class="font-medium">{{ $contesto['commessa'] ?: '—' }}</dd>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-slate-500">Destinatario</dt>
+                                        <dd class="font-medium">{{ $contesto['destinatario'] ?: '—' }}</dd>
+                                    </div>
+                                </dl>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <tr>
+                                        <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                        <th scope="col" class="px-4 py-3 text-right">Q.tà</th>
+                                        <th scope="col" class="px-4 py-3 text-left">Lotto</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white/80">
+                                    @foreach($riepilogo['righe'] ?? [] as $r)
+                                        <tr>
+                                            <td class="px-4 py-3 font-medium text-slate-700">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
+                                            <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['qta'] }}</td>
+                                            <td class="px-4 py-3 text-slate-600">{{ $r['lotto'] ?: '—' }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+                @endif
+
+                @if ($errors->has('general'))
+                    <div class="rounded-2xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700 shadow-sm">
+                        {{ $errors->first('general') }}
+                    </div>
+                @endif
+            </div>
+
+            <footer class="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button type="button" class="btn-secondary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="back" @disabled($step===1)>
+                    Indietro
+                </button>
+
+                <div class="flex items-center gap-3">
+                    @if($step < 3)
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="next">Avanti</span>
+                            <span wire:loading wire:target="next">Attendere…</span>
+                        </button>
+                    @else
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="conferma">Conferma operazione</span>
+                            <span wire:loading wire:target="conferma">Salvataggio…</span>
+                        </button>
+                    @endif
+                </div>
+            </footer>
+
+            @if (session('ok'))
+                <div class="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-700 shadow-sm">
+                    {{ session('ok') }}
+                </div>
+            @endif
         </div>
-      </div>
-      @error('contesto.tipo')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-
-      <div>
-        <label class="block text-sm font-medium">Magazzino</label>
-        <select wire:model="contesto.magazzino_id" class="w-full border rounded-xl p-2">
-          <option value="">— seleziona —</option>
-          @foreach($magazzini as $m)
-            <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-          @endforeach
-        </select>
-        @error('contesto.magazzino_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-      </div>
-
-      @if($ubicazioni->isNotEmpty())
-        <div>
-          <label class="block text-sm font-medium">Ubicazione</label>
-          <select wire:model="contesto.ubicazione_id" class="w-full border rounded-xl p-2">
-            <option value="">— seleziona —</option>
-            @foreach($ubicazioni as $u)
-              <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-            @endforeach
-          </select>
-          @error('contesto.ubicazione_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-      @elseif($contesto['magazzino_id'])
-        <p class="text-xs text-slate-500">Non ci sono ubicazioni attive per il magazzino selezionato.</p>
-      @endif
-
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm">Operatore</label>
-          <input type="text" wire:model.lazy="contesto.operatore" class="w-full border rounded-xl p-2" />
-          @error('contesto.operatore')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-        </div>
-        <div>
-          <label class="block text-sm">Commessa</label>
-          <input type="text" wire:model.lazy="contesto.commessa" class="w-full border rounded-xl p-2" />
-        </div>
-        <div>
-          <label class="block text-sm">Destinatario / Reparto</label>
-          <input type="text" wire:model.lazy="contesto.destinatario" class="w-full border rounded-xl p-2" placeholder="Es. sartoria, terzista..." />
-        </div>
-      </div>
-
-      <div>
-        <label class="block text-sm">Note</label>
-        <textarea wire:model.lazy="contesto.note" rows="3" class="w-full border rounded-xl p-2" placeholder="Dettagli aggiuntivi"></textarea>
-      </div>
     </div>
-  @endif
-
-  @if($step === 2)
-    <div class="card space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="font-medium">Articoli movimentati</h2>
-        <button type="button" wire:click="addRiga" class="btn-secondary">+ Aggiungi riga</button>
-      </div>
-
-      @foreach($righe as $i => $riga)
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-end">
-          <div class="md:col-span-6">
-            <label class="block text-sm">Articolo</label>
-            <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-xl p-2">
-              <option value="">— seleziona —</option>
-              @foreach($articoli as $a)
-                <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
-              @endforeach
-            </select>
-            @error("righe.$i.articolo_id")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-3">
-            <label class="block text-sm">Q.tà</label>
-            <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-xl p-2" />
-            @error("righe.$i.qta")<p class="text-sm text-red-600">{{ $message }}</p>@enderror
-          </div>
-          <div class="md:col-span-2">
-            <label class="block text-sm">Lotto (se presente)</label>
-            <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-xl p-2" />
-          </div>
-          <div class="md:col-span-1">
-            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-xl p-2 hover:bg-red-50">🗑️</button>
-          </div>
-        </div>
-        <hr class="border-dashed">
-      @endforeach
-    </div>
-  @endif
-
-  @if($step === 3)
-    <div class="card space-y-4">
-      <h2 class="font-medium">Riepilogo</h2>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div>
-          <div class="font-semibold">Operazione</div>
-          <div class="uppercase tracking-wide text-xs font-semibold"><x-ui.badge color="amber">{{ strtoupper($contesto['tipo']) }}</x-ui.badge></div>
-        </div>
-        <div>
-          <div class="font-semibold">Magazzino</div>
-          <div>{{ $riepilogo['magazzino'] ?? '—' }}</div>
-          @if($riepilogo['ubicazione'] ?? false)
-            <div class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['ubicazione'] }}</div>
-          @endif
-        </div>
-        <div>
-          <div class="font-semibold">Operatore</div>
-          <div>{{ $contesto['operatore'] }}</div>
-        </div>
-        <div>
-          <div class="font-semibold">Commessa</div>
-          <div>{{ $contesto['commessa'] ?: '—' }}</div>
-        </div>
-      </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="text-left py-2">Articolo</th>
-              <th class="text-right">Q.tà</th>
-              <th class="text-left">Lotto</th>
-            </tr>
-          </thead>
-          <tbody>
-            @foreach($riepilogo['righe'] ?? [] as $r)
-              <tr class="border-b">
-                <td class="py-2">{{ $r['codice'] }} — {{ $r['descrizione'] }}</td>
-                <td class="text-right">{{ $r['qta'] }}</td>
-                <td>{{ $r['lotto'] ?: '—' }}</td>
-              </tr>
-            @endforeach
-          </tbody>
-        </table>
-      </div>
-    </div>
-  @endif
-
-  <div class="flex justify-between">
-    <button type="button" class="btn-secondary" wire:click="back" @disabled($step===1)>Indietro</button>
-    @if($step < 3)
-      <button type="button" class="btn-primary" wire:click="next">Avanti</button>
-    @else
-      <button type="button" class="btn-primary" wire:click="conferma" wire:loading.attr="disabled">
-        <span wire:loading.remove>Conferma operazione</span>
-        <span wire:loading>Salvataggio…</span>
-      </button>
-    @endif
-  </div>
-
-  @if ($errors->has('general'))
-    <div class="p-3 rounded-xl bg-red-50 text-red-800">{{ $errors->first('general') }}</div>
-  @endif
-  @if (session('ok'))
-    <div class="p-3 rounded-xl bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>

--- a/resources/views/livewire/movimenti/transfer-wizard.blade.php
+++ b/resources/views/livewire/movimenti/transfer-wizard.blade.php
@@ -1,168 +1,260 @@
-{{-- resources/views/livewire/movimenti/transfer-wizard.blade.php --}}
-<div class="mx-auto max-w-5xl p-4 space-y-6">
-  <h1 class="text-2xl font-semibold">Trasferimento tra magazzini</h1>
+@php
+    $steps = [
+        1 => ['label' => 'Origine', 'subtitle' => 'Magazzino di partenza'],
+        2 => ['label' => 'Destinazione', 'subtitle' => 'Magazzino di arrivo'],
+        3 => ['label' => 'Articoli', 'subtitle' => 'Quantità e lotti'],
+        4 => ['label' => 'Riepilogo', 'subtitle' => 'Controlla e conferma'],
+    ];
+@endphp
 
-  {{-- Stepper --}}
-  <div class="flex items-center gap-2 text-sm">
-    @foreach ([1=>'Origine',2=>'Destinazione',3=>'Articoli',4=>'Riepilogo',5=>'Conferma'] as $i=>$label)
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{ $step >= $i ? 'bg-blue-600 text-white' : 'bg-gray-200' }}">{{ $i }}</div>
-        <span class="{{ $step >= $i ? 'font-medium' : 'text-gray-500' }}">{{ $label }}</span>
-      </div>
-      @if($i<5)<div class="flex-1 h-px bg-gray-200"></div>@endif
-    @endforeach
-  </div>
+<div class="wizard-shell min-h-screen bg-gradient-to-br from-slate-50 via-white to-brand-50 pb-10 pt-6">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 lg:px-6">
+        <section class="relative overflow-hidden rounded-3xl border border-white/60 bg-white/85 p-8 shadow-lg backdrop-blur">
+            <div class="absolute -left-12 bottom-0 hidden h-56 w-56 rotate-12 rounded-full bg-brand-100 blur-3xl md:block"></div>
+            <img src="{{ asset('images/loom-weave.svg') }}" alt="Illustrazione trasferimento" class="absolute -right-8 bottom-0 w-56 opacity-80 md:w-72" aria-hidden="true">
+            <div class="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold uppercase tracking-wider text-brand-600">Movimenti • Trasferimento</p>
+                    <h1 class="text-3xl font-semibold text-slate-900">Trasferisci materiale tra magazzini con un flusso guidato</h1>
+                    <p class="max-w-2xl text-sm text-slate-600">Segui i quattro step per scegliere origine, destinazione e articoli. Il riepilogo finale ti permette di validare tutto prima del salvataggio.</p>
+                </div>
+                <div class="grid gap-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-sm text-slate-600 shadow-sm md:w-72">
+                    <div>
+                        <p class="font-semibold text-slate-500">Origine selezionata</p>
+                        <p class="text-base font-semibold text-slate-900">
+                            @php($origineMag = $magazzini->firstWhere('id', $origine['magazzino_id']))
+                            {{ $origineMag?->descrizione ?? '—' }}
+                        </p>
+                    </div>
+                    <div>
+                        <p class="font-semibold text-slate-500">Destinazione</p>
+                        <p class="text-base font-semibold text-slate-900">
+                            @php($destMag = $magazzini->firstWhere('id', $destinazione['magazzino_id']))
+                            {{ $destMag?->descrizione ?? '—' }}
+                        </p>
+                    </div>
+                    <p class="text-xs uppercase tracking-wide text-brand-600">Step {{ $step }} di {{ count($steps) }}</p>
+                </div>
+            </div>
+        </section>
 
-  {{-- Step 1: Origine --}}
-  @if($step===1)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-3">
-    <label class="block text-sm font-medium">Magazzino di origine</label>
-    <select wire:model="origine.magazzino_id" class="w-full border rounded-lg p-2">
-      <option value="">— seleziona —</option>
-      @foreach($magazzini as $m)
-        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-      @endforeach
-    </select>
-    @error('origine.magazzino_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
+        <div class="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur">
+            <ol class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+                @foreach($steps as $index => $info)
+                    <li class="relative flex flex-1 items-start gap-3 sm:flex-col sm:items-center sm:text-center">
+                        <span class="flex h-11 w-11 items-center justify-center rounded-2xl border text-sm font-semibold transition @if($step > $index) border-brand-600 bg-brand-600 text-white shadow-md @elseif($step === $index) border-brand-600 bg-brand-50 text-brand-700 shadow @else border-slate-200 bg-white text-slate-400 @endif">
+                            {{ $index }}
+                        </span>
+                        <div class="flex-1 sm:flex sm:flex-col sm:items-center">
+                            <p class="text-sm font-semibold text-slate-900">{{ $info['label'] }}</p>
+                            <p class="text-xs text-slate-500">{{ $info['subtitle'] }}</p>
+                        </div>
+                        @if($index < count($steps))
+                            <span class="absolute left-5 top-5 hidden h-px w-full translate-y-1/2 bg-gradient-to-r from-slate-200 via-slate-100 to-slate-200 sm:block"></span>
+                        @endif
+                    </li>
+                @endforeach
+            </ol>
 
-    @if($origineUbicazioni->isNotEmpty())
-      <label class="block text-sm font-medium">Ubicazione di origine</label>
-      <select wire:model="origine.ubicazione_id" class="w-full border rounded-lg p-2">
-        <option value="">— seleziona —</option>
-        @foreach($origineUbicazioni as $u)
-          <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-        @endforeach
-      </select>
-      @error('origine.ubicazione_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @elseif($origine['magazzino_id'])
-      <p class="text-xs text-slate-500">Questo magazzino non ha ubicazioni attive: il trasferimento userà l'intero magazzino.</p>
-    @endif
-  </div>
-  @endif
+            <div class="mt-8 space-y-6">
+                @if($step === 1)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Scegli il magazzino di origine</h2>
+                            <p class="text-sm text-slate-600">Definisci da dove prelevare gli articoli e, se necessario, l&#39;ubicazione precisa.</p>
+                        </header>
 
-  {{-- Step 2: Destinazione --}}
-  @if($step===2)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-3">
-    <label class="block text-sm font-medium">Magazzino di destinazione</label>
-    <select wire:model="destinazione.magazzino_id" class="w-full border rounded-lg p-2">
-      <option value="">— seleziona —</option>
-      @foreach($magazzini as $m)
-        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
-      @endforeach
-    </select>
-    @error('destinazione.magazzino_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @if($destinazioneUbicazioni->isNotEmpty())
-      <label class="block text-sm font-medium">Ubicazione di destinazione</label>
-      <select wire:model="destinazione.ubicazione_id" class="w-full border rounded-lg p-2">
-        <option value="">— seleziona —</option>
-        @foreach($destinazioneUbicazioni as $u)
-          <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
-        @endforeach
-      </select>
-      @error('destinazione.ubicazione_id')<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-    @elseif($destinazione['magazzino_id'])
-      <p class="text-xs text-slate-500">Non sono presenti ubicazioni attive per il magazzino scelto.</p>
-    @endif
-  </div>
-  @endif
+                        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                            <div class="space-y-2">
+                                <label for="origine-magazzino" class="text-sm font-semibold text-slate-700">Magazzino di origine</label>
+                                <select id="origine-magazzino" wire:model="origine.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($magazzini as $m)
+                                        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                    @endforeach
+                                </select>
+                                @error('origine.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
 
-  {{-- Step 3: Articoli --}}
-  @if($step===3)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-4">
-    <div class="flex justify-between items-center">
-      <h2 class="font-medium">Articoli da trasferire</h2>
-      <button wire:click="addRiga" type="button" class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200">+ Aggiungi riga</button>
+                            <div class="space-y-2">
+                                <label for="origine-ubicazione" class="text-sm font-semibold text-slate-700">Ubicazione di origine</label>
+                                <select id="origine-ubicazione" wire:model="origine.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($origineUbicazioni as $u)
+                                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                    @endforeach
+                                </select>
+                                @error('origine.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                @if($origineUbicazioni->isEmpty() && $origine['magazzino_id'])
+                                    <p class="text-xs text-slate-500">Questo magazzino non ha ubicazioni attive: il trasferimento partirà dal magazzino generale.</p>
+                                @endif
+                            </div>
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 2)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Imposta la destinazione</h2>
+                            <p class="text-sm text-slate-600">Scegli il magazzino di arrivo e, se necessario, l&#39;ubicazione in cui stoccare la merce.</p>
+                        </header>
+
+                        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                            <div class="space-y-2">
+                                <label for="dest-magazzino" class="text-sm font-semibold text-slate-700">Magazzino di destinazione</label>
+                                <select id="dest-magazzino" wire:model="destinazione.magazzino_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($magazzini as $m)
+                                        <option value="{{ $m->id }}">{{ $m->descrizione }} ({{ $m->codice }})</option>
+                                    @endforeach
+                                </select>
+                                @error('destinazione.magazzino_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                            </div>
+
+                            <div class="space-y-2">
+                                <label for="dest-ubicazione" class="text-sm font-semibold text-slate-700">Ubicazione di destinazione</label>
+                                <select id="dest-ubicazione" wire:model="destinazione.ubicazione_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                    <option value="">— seleziona —</option>
+                                    @foreach($destinazioneUbicazioni as $u)
+                                        <option value="{{ $u->id }}">{{ $u->codice }} — {{ $u->descrizione }}</option>
+                                    @endforeach
+                                </select>
+                                @error('destinazione.ubicazione_id')<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                @if($destinazioneUbicazioni->isEmpty() && $destinazione['magazzino_id'])
+                                    <p class="text-xs text-slate-500">Non sono presenti ubicazioni attive per il magazzino selezionato.</p>
+                                @endif
+                            </div>
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 3)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <header>
+                                <h2 class="text-lg font-semibold text-slate-900">Articoli da trasferire</h2>
+                                <p class="text-sm text-slate-600">Inserisci tutte le righe con articolo, quantità e lotto opzionale.</p>
+                            </header>
+                            <button type="button" wire:click="addRiga" class="btn-secondary rounded-2xl px-4 py-2 text-sm font-semibold text-brand-600 shadow-sm hover:bg-brand-50 hover:text-brand-700">
+                                + Aggiungi riga
+                            </button>
+                        </div>
+
+                        <div class="space-y-6">
+                            @foreach($righe as $i => $riga)
+                                <article wire:key="transfer-riga-{{ $i }}" class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                    <div class="grid grid-cols-1 gap-4 md:grid-cols-12">
+                                        <div class="md:col-span-6 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="articolo-{{ $i }}">Articolo</label>
+                                            <select id="articolo-{{ $i }}" wire:model="righe.{{ $i }}.articolo_id" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                                <option value="">— seleziona —</option>
+                                                @foreach($articoli as $a)
+                                                    <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
+                                                @endforeach
+                                            </select>
+                                            @error("righe.$i.articolo_id")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+                                        <div class="md:col-span-3 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="qta-{{ $i }}">Q.tà</label>
+                                            <input id="qta-{{ $i }}" type="number" min="0" step="0.001" wire:model.lazy="righe.{{ $i }}.qta" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                            @error("righe.$i.qta")<p class="text-sm text-rose-600">{{ $message }}</p>@enderror
+                                        </div>
+                                        <div class="md:col-span-2 space-y-2">
+                                            <label class="text-sm font-semibold text-slate-700" for="lotto-{{ $i }}">Lotto</label>
+                                            <input id="lotto-{{ $i }}" type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full rounded-2xl border-slate-200 bg-white/90 p-3 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500">
+                                        </div>
+                                        <div class="md:col-span-1 flex items-end">
+                                            <button type="button" wire:click="removeRiga({{ $i }})" class="w-full rounded-2xl border border-rose-200 bg-rose-50/80 p-3 text-sm font-semibold text-rose-600 shadow-sm transition hover:bg-rose-100">
+                                                🗑️
+                                            </button>
+                                        </div>
+                                    </div>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                @if($step === 4)
+                    <section class="space-y-6 rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
+                        <header class="space-y-1">
+                            <h2 class="text-lg font-semibold text-slate-900">Riepilogo trasferimento</h2>
+                            <p class="text-sm text-slate-600">Controlla attentamente i dati prima di confermare il movimento.</p>
+                        </header>
+
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Origine</h3>
+                                <p class="text-base font-semibold text-slate-900">{{ $origineMag?->descrizione ?? '—' }}</p>
+                                @if($riepilogo['origine']['ubicazione_label'] ?? false)
+                                    <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['origine']['ubicazione_label'] }}</p>
+                                @endif
+                            </div>
+                            <div class="rounded-2xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+                                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Destinazione</h3>
+                                <p class="text-base font-semibold text-slate-900">{{ $destMag?->descrizione ?? '—' }}</p>
+                                @if($riepilogo['destinazione']['ubicazione_label'] ?? false)
+                                    <p class="text-xs text-slate-500">Ubicazione: {{ $riepilogo['destinazione']['ubicazione_label'] }}</p>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-2xl border border-slate-200/70">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50/70 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <tr>
+                                        <th scope="col" class="px-4 py-3 text-left">Articolo</th>
+                                        <th scope="col" class="px-4 py-3 text-right">Q.tà</th>
+                                        <th scope="col" class="px-4 py-3 text-left">Lotto</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white/80">
+                                    @foreach($riepilogo['righe'] ?? [] as $r)
+                                        <tr>
+                                            <td class="px-4 py-3 font-medium text-slate-700">{{ $r['codice'] }} — {{ $r['descr'] }}</td>
+                                            <td class="px-4 py-3 text-right font-semibold text-slate-900">{{ $r['qta'] }}</td>
+                                            <td class="px-4 py-3 text-slate-600">{{ $r['lotto'] ?: '—' }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+                @endif
+
+                @if ($errors->has('general'))
+                    <div class="rounded-2xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700 shadow-sm">
+                        {{ $errors->first('general') }}
+                    </div>
+                @endif
+            </div>
+
+            <footer class="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <button type="button" class="btn-secondary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="back" @disabled($step===1)>
+                    Indietro
+                </button>
+
+                <div class="flex items-center gap-3">
+                    @if($step < 4)
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="next" wire:target="next" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="next">Avanti</span>
+                            <span wire:loading wire:target="next">Attendere…</span>
+                        </button>
+                    @else
+                        <button type="button" class="btn-primary rounded-2xl px-5 py-2 text-sm font-semibold" wire:click="conferma" wire:target="conferma" wire:loading.attr="disabled">
+                            <span wire:loading.remove wire:target="conferma">Conferma trasferimento</span>
+                            <span wire:loading wire:target="conferma">Salvataggio…</span>
+                        </button>
+                    @endif
+                </div>
+            </footer>
+
+            @if (session('ok'))
+                <div class="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-700 shadow-sm">
+                    {{ session('ok') }}
+                </div>
+            @endif
+        </div>
     </div>
-    @foreach($righe as $i => $r)
-      <div class="grid grid-cols-1 md:grid-cols-12 gap-2 items-end">
-        <div class="md:col-span-6">
-          <label class="block text-sm">Articolo</label>
-          <select wire:model="righe.{{ $i }}.articolo_id" class="w-full border rounded-lg p-2">
-            <option value="">— seleziona —</option>
-            @foreach($articoli as $a)
-              <option value="{{ $a->id }}">{{ $a->codice }} — {{ $a->descrizione }}</option>
-            @endforeach
-          </select>
-          @error("righe.$i.articolo_id")<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-        </div>
-        <div class="md:col-span-3">
-          <label class="block text-sm">Q.tà</label>
-          <input type="number" step="0.001" min="0" wire:model.lazy="righe.{{ $i }}.qta" class="w-full border rounded-lg p-2" />
-          @error("righe.$i.qta")<p class="text-red-600 text-sm">{{ $message }}</p>@enderror
-        </div>
-        <div class="md:col-span-2">
-          <label class="block text-sm">Lotto (opz.)</label>
-          <input type="text" wire:model.lazy="righe.{{ $i }}.lotto" class="w-full border rounded-lg p-2" />
-        </div>
-        <div class="md:col-span-1">
-          <button type="button" wire:click="removeRiga({{ $i }})" class="w-full border rounded-lg p-2 hover:bg-red-50">🗑️</button>
-        </div>
-      </div>
-      <hr class="my-2">
-    @endforeach
-  </div>
-  @endif
-
-  {{-- Step 4: Riepilogo --}}
-  @if($step===4)
-  <div class="bg-white rounded-2xl shadow p-4 space-y-4">
-    <p class="text-sm">Controlla i dati e procedi alla conferma.</p>
-    <ul class="text-sm space-y-1">
-      <li>
-        <strong>Origine:</strong>
-        {{ optional($magazzini->firstWhere('id', $origine['magazzino_id']))?->descrizione }}
-        @if(!empty($riepilogo['origine']['ubicazione_label']))
-          <span class="block text-xs text-slate-500">Ubicazione: {{ $riepilogo['origine']['ubicazione_label'] }}</span>
-        @endif
-      </li>
-      <li>
-        <strong>Destinazione:</strong>
-        {{ optional($magazzini->firstWhere('id', $destinazione['magazzino_id']))?->descrizione }}
-        @if(!empty($riepilogo['destinazione']['ubicazione_label']))
-          <span class="block text-xs text-slate-500">Ubicazione: {{ $riepilogo['destinazione']['ubicazione_label'] }}</span>
-        @endif
-      </li>
-    </ul>
-    <div class="overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead><tr class="border-b">
-          <th class="text-left py-2">Articolo</th><th class="text-right">Q.tà</th><th class="text-left">Lotto</th>
-        </tr></thead>
-        <tbody>
-          @foreach($riepilogo['righe'] ?? [] as $r)
-            <tr class="border-b">
-              <td class="py-2">{{ $r['codice'] }} — {{ $r['descr'] }}</td>
-              <td class="text-right">{{ $r['qta'] }}</td>
-              <td>{{ $r['lotto'] }}</td>
-            </tr>
-          @endforeach
-        </tbody>
-      </table>
-    </div>
-  </div>
-  @endif
-
-  {{-- Navigazione --}}
-  <div class="flex justify-between">
-    <button type="button" wire:click="back" @disabled($step===1)
-      class="px-4 py-2 rounded-lg border">Indietro</button>
-
-    @if($step<4)
-      <button type="button" wire:click="next" class="px-4 py-2 rounded-lg bg-blue-600 text-white">Avanti</button>
-    @elseif($step===4)
-    <button type="button" wire:click="conferma" wire:loading.attr="disabled" class="px-4 py-2 rounded-lg bg-green-600 text-white">
-        <span wire:loading.remove>Conferma trasferimento</span>
-        <span wire:loading>Salvo…</span>
-    </button>
-
-    @endif
-  </div>
-  @if ($errors->has('general'))
-  <div class="p-3 rounded-lg bg-red-50 text-red-800 mt-3">
-    {{ $errors->first('general') }}
-  </div>
-@endif
-  @if (session('ok'))
-    <div class="p-3 rounded-lg bg-green-50 text-green-800">{{ session('ok') }}</div>
-  @endif
 </div>


### PR DESCRIPTION
## Summary
- reinforce movement wizard navigation with explicit step bounds, validation catches, and helpful fallback messaging across carico, scarico, trasferimento e conto-lavoro componenti
- ridisegna tutte le maschere dei wizard con hero illustrati, stepper responsive e pannelli arrotondati pensati anche per l'uso mobile
- aggiungi nuove illustrazioni SVG a tema magazzino e tessile per supportare la grafica aggiornata

## Testing
- php artisan test *(fails: vendor/autoload.php mancante nell'ambiente di esecuzione)*

------
https://chatgpt.com/codex/tasks/task_e_68db943f02d8832dbc95e0074ea04004